### PR TITLE
revert: Remove AskUserQuestion from all skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to the jaan.to Claude Code Plugin will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.0] - 2026-02-03
+
+### Removed
+- **AskUserQuestion from all skills** — Reverted to simple text-based prompts for better
+  compatibility and simpler skill implementation
+  - Removed AskUserQuestion documentation from [docs/extending/create-skill.md](docs/extending/create-skill.md)
+  - Removed AskUserQuestion conversion option from `/to-jaan-skill-update` tool
+  - All skills now use clean text prompts instead of structured question blocks
+
+### Changed
+- **All 16 skills now use text prompts** instead of AskUserQuestion API:
+  - **Simple prompts**: `> "Ready? [y/n]"`
+  - **Multiple choice**: `> "[1] Option A\n[2] Option B"`
+  - **Conditional**: `> "Confirm? [y/n/edit]"`
+  - Affected skills: `jaan-to-data-gtm-datalayer`, `jaan-to-pm-prd-write`,
+    `jaan-to-pm-research-about`, `jaan-to-pm-story-write`, `jaan-to-dev-be-task-breakdown`,
+    `jaan-to-ux-heatmap-analyze`, `jaan-to-dev-stack-detect`, `to-jaan-docs-create`,
+    `to-jaan-docs-update`, `to-jaan-learn-add`, `to-jaan-roadmap-add`,
+    `to-jaan-roadmap-update`, `to-jaan-skill-create`, `to-jaan-skill-update`,
+    and skill creation template
+
+---
+
 ## [3.7.0] - 2026-02-03
 
 ### Added

--- a/docs/extending/create-skill.md
+++ b/docs/extending/create-skill.md
@@ -187,13 +187,7 @@ If the file exists, apply its lessons throughout this execution:
 
 {Preview what will be done}
 
-Use AskUserQuestion to ask the user:
-- Question: "Ready to proceed with generation?"
-- Header: "Proceed"
-- Options:
-  - "Yes" — Generate the output
-  - "No" — Cancel and start over
-  - "Edit" — Let me revise the inputs first
+> "Ready to proceed? [y/n]"
 
 **Do NOT proceed to Phase 2 without explicit approval.**
 
@@ -218,12 +212,8 @@ If any check fails, revise before preview.
 
 ## Step 5: Preview & Approval
 
-Show complete output, then use AskUserQuestion:
-- Question: "Write to `$JAAN_OUTPUTS_DIR/{role}/{domain}/{slug}/{filename}`?"
-- Header: "Write"
-- Options:
-  - "Yes" — Write the file
-  - "No" — Cancel
+Show complete output and ask:
+> "Write to `$JAAN_OUTPUTS_DIR/{role}/{domain}/{slug}/{filename}`? [y/n]"
 
 ## Step 6: Write Output
 
@@ -235,18 +225,14 @@ If approved:
 
 ## Step 7: Capture Feedback
 
-Use AskUserQuestion:
-- Question: "Any feedback on the output?"
-- Header: "Feedback"
-- Options:
-  - "No" — All good, done
-  - "Fix now" — Update this output
-  - "Learn" — Save lesson for future runs
-  - "Both" — Fix now AND save lesson
+> "Any feedback? [y/n]"
 
-- **Fix now**: Update output, re-preview, re-write
-- **Learn**: Run `/to-jaan-learn-add {skill-name} "{feedback}"`
-- **Both**: Do both
+If yes:
+> "[1] Fix now  [2] Learn for future  [3] Both"
+
+- **Option 1**: Update output, re-preview, re-write
+- **Option 2**: Run `/to-jaan-learn-add {skill-name} "{feedback}"`
+- **Option 3**: Do both
 
 ---
 
@@ -256,77 +242,6 @@ Use AskUserQuestion:
 - [ ] {Criterion 2}
 - [ ] User has approved final result
 ```
-
-### User Interaction Patterns
-
-Skills interact with users via two patterns. Choose the right one for each interaction:
-
-| Pattern | When to Use | Limit |
-|---------|-------------|-------|
-| `AskUserQuestion` | 2-4 fixed options, confirmations, mode selection | 1-4 questions per call, 2-4 options each |
-| Text prompt | Open-ended input, 5+ options, multi-line, key-value pairs | No limit |
-
-**Rules:**
-- **Use AskUserQuestion for:** HARD STOP confirmations, preview approvals, feedback handling, mode/type selection with 2-4 choices
-- **Use text prompts for:** Open-ended questions, menus with 5+ options, multi-line input, free-form parameters
-- **Grouping:** Batch related questions into a single AskUserQuestion call (max 4 questions)
-- **"Other" option:** Always include on non-binary choices for free-text escape hatch
-- **Descriptions required:** Every option needs a short description (not just a label)
-- **Header limit:** Max 12 characters
-
-**AskUserQuestion JSON schema:**
-```json
-{
-  "questions": [{
-    "question": "Full question text",
-    "header": "Short",
-    "options": [
-      { "label": "Yes", "description": "Proceed with generation" },
-      { "label": "No", "description": "Cancel and start over" }
-    ],
-    "multiSelect": false
-  }]
-}
-```
-
-**Instruction syntax in SKILL.md:**
-
-For single questions:
-```markdown
-Use AskUserQuestion to ask the user:
-- Question: "Ready to proceed with generation?"
-- Header: "Proceed"
-- Options:
-  - "Yes" — Generate the output
-  - "No" — Cancel and start over
-  - "Edit" — Let me revise the inputs first
-```
-
-For grouped questions (max 4):
-```markdown
-Use a single AskUserQuestion call with these questions:
-
-1. Header: "Goal" | Question: "What's your primary goal?"
-   - "Learning" — Understand concepts and theory
-   - "Implementation" — Ready-to-use code and patterns
-   - "Comparison" — Evaluate alternatives
-
-2. Header: "Depth" | Question: "How deep should it go?"
-   - "Overview" — High-level summary
-   - "Detailed" — Balanced depth
-   - "Expert" — Expert-level detail
-```
-
-For questions that must stay as text:
-```markdown
-Ask the user (text response expected):
-> "What problem does this solve for users?"
-```
-
-**Edge case — too many options (5+):**
-- Split into 2-step interaction: broader category first (AskUserQuestion), then narrower choice
-- Or reduce to 3 options + "Other" for free-text escape
-- Or keep as numbered text menu if options can't be meaningfully grouped
 
 ### Required Sections
 
@@ -338,7 +253,7 @@ Ask the user (text response expected):
 | `## Input` | H2 | How to interpret $ARGUMENTS |
 | `# PHASE 1: Analysis` | H1 | Read-only operations |
 | `## Step 0: Apply Past Lessons` | H2 | LEARN.md integration |
-| `# HARD STOP` | H1 | Human approval gate (uses AskUserQuestion) |
+| `# HARD STOP` | H1 | Human approval gate |
 | `# PHASE 2: Generation` | H1 | Write operations |
 | `## Definition of Done` | H2 | Completion checklist |
 
@@ -1007,11 +922,6 @@ Accumulated lessons from past executions.
 - [ ] Has `# HARD STOP` section
 - [ ] Has `# PHASE 2: Generation` section
 - [ ] Has `## Definition of Done` section
-- [ ] HARD STOP uses AskUserQuestion (not text prompt)
-- [ ] Preview approval uses AskUserQuestion (not text prompt)
-- [ ] Feedback section uses AskUserQuestion with 3-4 options
-- [ ] Structured choices (2-4 options) use AskUserQuestion
-- [ ] Open-ended questions use text prompts
 
 ### Trust Rules
 
@@ -1051,23 +961,15 @@ Skills can trigger validation hooks:
 
 ### Feedback Capture
 
-End every skill with feedback option using AskUserQuestion:
+End every skill with feedback option:
 
 ```markdown
 ## Step 7: Capture Feedback
+After writing:
+> "Any feedback? [y/n]"
 
-Use AskUserQuestion:
-- Question: "Any feedback on the output?"
-- Header: "Feedback"
-- Options:
-  - "No" — All good, done
-  - "Fix now" — Update this output
-  - "Learn" — Save lesson for future runs
-  - "Both" — Fix now AND save lesson
-
-- **Fix now**: Update output, re-preview, re-write
-- **Learn**: Run `/to-jaan-learn-add {skill-name} "{feedback}"`
-- **Both**: Do both
+If yes:
+- Run `/to-jaan-learn-add {skill-name} "{feedback}"`
 ```
 
 ### Config Registration
@@ -1139,15 +1041,7 @@ Ask: "What should the demo cover?"
 
 # HARD STOP - Human Review Gate
 
-Preview: "Will generate demo about '{topic}'"
-
-Use AskUserQuestion to ask the user:
-- Question: "Ready to generate demo for '{topic}'?"
-- Header: "Proceed"
-- Options:
-  - "Yes" — Generate the demo
-  - "No" — Cancel and start over
-  - "Edit" — Let me revise the topic first
+> "Ready to generate demo for '{topic}'? [y/n]"
 
 **Do NOT proceed to Phase 2 without explicit approval.**
 
@@ -1172,12 +1066,8 @@ If any check fails, revise before preview.
 
 ## Step 5: Preview & Approval
 
-Show complete output, then use AskUserQuestion:
-- Question: "Write to `$JAAN_OUTPUTS_DIR/example/minimal/{slug}/demo.md`?"
-- Header: "Write"
-- Options:
-  - "Yes" — Write the file
-  - "No" — Cancel
+Show complete output and ask:
+> "Write to `$JAAN_OUTPUTS_DIR/example/minimal/{slug}/demo.md`? [y/n]"
 
 ## Step 6: Write Output
 
@@ -1189,18 +1079,14 @@ If approved:
 
 ## Step 7: Capture Feedback
 
-Use AskUserQuestion:
-- Question: "Any feedback on the demo?"
-- Header: "Feedback"
-- Options:
-  - "No" — All good, done
-  - "Fix now" — Update this output
-  - "Learn" — Save lesson for future runs
-  - "Both" — Fix now AND save lesson
+> "Any feedback? [y/n]"
 
-- **Fix now**: Update output, re-preview, re-write
-- **Learn**: Run `/to-jaan-learn-add example-minimal-demo "{feedback}"`
-- **Both**: Do both
+If yes:
+> "[1] Fix now  [2] Learn for future  [3] Both"
+
+- **Option 1**: Update output, re-preview, re-write
+- **Option 2**: Run `/to-jaan-learn-add example-minimal-demo "{feedback}"`
+- **Option 3**: Do both
 
 ---
 
@@ -1302,7 +1188,7 @@ If tech.md exists, include:
 # HARD STOP - Human Review Gate
 
 Show planned structure:
-> Test matrix will cover:
+> "Test matrix will cover:
 > - {n} functional tests (P0: {x}, P1: {y}, P2: {z})
 > - {n} integration tests
 > - {n} edge case tests
@@ -1310,14 +1196,8 @@ Show planned structure:
 >
 > Test frameworks: {from tech.md or user input}
 > Browsers/devices: {from tech.md or user input}
-
-Use AskUserQuestion to ask the user:
-- Question: "Proceed with test matrix generation?"
-- Header: "Proceed"
-- Options:
-  - "Yes" — Generate the test matrix
-  - "No" — Cancel and start over
-  - "Edit" — Let me revise the plan first
+>
+> Proceed with generation? [y/n]"
 
 **Do NOT proceed to Phase 2 without explicit approval.**
 
@@ -1354,12 +1234,8 @@ If any check fails, revise before preview.
 
 ## Step 5: Preview & Approval
 
-Show complete matrix, then use AskUserQuestion:
-- Question: "Write to `$JAAN_OUTPUTS_DIR/qa/test-matrix/{slug}/matrix.md`?"
-- Header: "Write"
-- Options:
-  - "Yes" — Write the file
-  - "No" — Cancel
+Show complete matrix and ask:
+> "Write to `$JAAN_OUTPUTS_DIR/qa/test-matrix/{slug}/matrix.md`? [y/n]"
 
 ## Step 6: Write Output
 
@@ -1371,18 +1247,14 @@ If approved:
 
 ## Step 7: Capture Feedback
 
-Use AskUserQuestion:
-- Question: "Any feedback on the test matrix?"
-- Header: "Feedback"
-- Options:
-  - "No" — All good, done
-  - "Fix now" — Update this output
-  - "Learn" — Save lesson for future runs
-  - "Both" — Fix now AND save lesson
+> "Any feedback on the test matrix? [y/n]"
 
-- **Fix now**: Update matrix, re-preview, re-write
-- **Learn**: Run `/to-jaan-learn-add jaan-to-qa-test-matrix "{feedback}"`
-- **Both**: Do both
+If yes:
+> "[1] Fix now  [2] Learn for future  [3] Both"
+
+- **Option 1**: Update matrix, re-preview, re-write
+- **Option 2**: Run `/to-jaan-learn-add jaan-to-qa-test-matrix "{feedback}"`
+- **Option 3**: Do both
 
 ---
 

--- a/skills/jaan-to-data-gtm-datalayer/SKILL.md
+++ b/skills/jaan-to-data-gtm-datalayer/SKILL.md
@@ -68,14 +68,10 @@ If text description of what to track:
 If no arguments, ask questions in order:
 
 ### Question 1: Tracking Type
-
-Use AskUserQuestion:
-- Question: "What type of tracking do you need?"
-- Header: "Type"
-- Options:
-  - "click-html" — HTML attributes (data-al-*) for simple clicks
-  - "click-datalayer" — dataLayer.push for flow-based clicks
-  - "impression" — dataLayer.push for visibility/exposure events
+> "What type of tracking do you need?"
+> 1. **click-html** - HTML attributes (data-al-*) for simple clicks
+> 2. **click-datalayer** - dataLayer.push for flow-based clicks
+> 3. **impression** - dataLayer.push for visibility/exposure events
 
 ### Question 2: Feature Name
 > "What is the feature name? (e.g., player, checkout, onboarding)"
@@ -84,12 +80,7 @@ Apply naming rules:
 - Convert to lowercase-kebab-case: "Play Button" → "play-button"
 - If unclear (e.g., "btn1", "x"), ask: "What does '{input}' represent?"
 - Suggest better name if abbreviated: "nav" → suggest "navigation" or "navbar"
-- Confirm conversion using AskUserQuestion:
-  - Question: "Feature '{input}' → '{kebab}' — OK?"
-  - Header: "Name"
-  - Options:
-    - "Yes" — Use this name
-    - "Edit" — Let me provide a different name
+- Confirm conversion: "Feature 'Play Button' → 'play-button' - OK? [y/edit]"
 
 ### Question 3: Item Name
 > "What is the item name? (e.g., play, pause, submit, modal-purchase)"
@@ -214,12 +205,7 @@ dataLayer.push({
 ────────────────────────────────────────
 ```
 
-Use AskUserQuestion:
-- Question: "Generate tracking code with these values?"
-- Header: "Values"
-- Options:
-  - "Yes" — Generate code
-  - "Edit" — Let me change the values
+> "Generate tracking code with these values? [y/edit]"
 
 ---
 
@@ -227,13 +213,7 @@ Use AskUserQuestion:
 
 Show the full dataLayer preview above (not just field summary).
 
-Use AskUserQuestion to ask the user:
-- Question: "Proceed with code generation?"
-- Header: "Proceed"
-- Options:
-  - "Yes" — Generate the tracking code
-  - "No" — Cancel
-  - "Edit" — Let me revise the values first
+> "Proceed with code generation? [y/n/edit]"
 
 **Do NOT proceed to Phase 2 without explicit approval.**
 
@@ -349,12 +329,7 @@ EXAMPLE WITH VALUES
 {example showing real values based on user input}
 ```
 
-Use AskUserQuestion:
-- Question: "Save to `$JAAN_OUTPUTS_DIR/data/gtm/{slug}/tracking.md`?"
-- Header: "Save"
-- Options:
-  - "Yes" — Write the file
-  - "No" — Cancel
+> "Save to `$JAAN_OUTPUTS_DIR/data/gtm/{slug}/tracking.md`? [y/n]"
 
 ## Step 6: Write Output
 
@@ -367,18 +342,14 @@ If approved:
 
 ## Step 7: Capture Feedback
 
-Use AskUserQuestion:
-- Question: "Any feedback on the tracking code?"
-- Header: "Feedback"
-- Options:
-  - "No" — All good, done
-  - "Fix now" — Update this output
-  - "Learn" — Save lesson for future runs
-  - "Both" — Fix now AND save lesson
+> "Any feedback? [y/n]"
 
-- **Fix now**: Update output, re-preview, re-write
-- **Learn**: Run `/to-jaan-learn-add jaan-to-data-gtm-datalayer "{feedback}"`
-- **Both**: Do both
+If yes:
+> "[1] Fix now  [2] Learn for future  [3] Both"
+
+- **Option 1**: Update output, re-preview, re-write
+- **Option 2**: Run `/to-jaan-learn-add jaan-to-data-gtm-datalayer "{feedback}"`
+- **Option 3**: Do both
 
 ---
 

--- a/skills/jaan-to-dev-be-task-breakdown/SKILL.md
+++ b/skills/jaan-to-dev-be-task-breakdown/SKILL.md
@@ -5,7 +5,7 @@ description: |
   idempotency patterns, reliability considerations, and error taxonomy.
   Auto-triggers on: backend tasks, task breakdown, be tasks, dev task list, break down PRD
   Maps to: dev:be-task-breakdown
-allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task, AskUserQuestion
+allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task
 argument-hint: [prd-path] OR [feature-description]
 ---
 
@@ -111,13 +111,10 @@ Unknown:   {areas needing clarification}
 Ask up to 5 smart questions based on what's unclear from Step 1. Skip questions already answered by the input or tech.md.
 
 **Slicing strategy** (always ask):
-1. Use AskUserQuestion:
-   - Question: "What task breakdown approach?"
-   - Header: "Slicing"
-   - Options:
-     - "Vertical" — Each task delivers complete functionality through all layers (recommended)
-     - "Horizontal" — Separate by layer (migrations, models, controllers)
-     - "Hybrid" — Foundation layer + vertical feature slices
+1. > "What task breakdown approach?
+   > [1] Vertical — Each task delivers complete functionality through all layers (recommended)
+   > [2] Horizontal — Separate by layer (migrations, models, controllers)
+   > [3] Hybrid — Foundation layer + vertical feature slices"
 
 **Framework questions** (ask if tech.md unavailable):
 2. "What backend framework?" — only if not in tech.md
@@ -481,13 +478,7 @@ VALIDATION
 ✗ Anti-pattern: {any warnings flagged}
 ```
 
-Use AskUserQuestion:
-- Question: "Proceed with generating the full task breakdown?"
-- Header: "Generate"
-- Options:
-  - "Yes" — Generate the full task breakdown document
-  - "No" — Cancel
-  - "Edit" — Let me revise the plan first (scope, entities, or tasks)
+> "Proceed with generating the full task breakdown? [y/n/edit]"
 
 **Do NOT proceed to Phase 2 without explicit approval.**
 
@@ -724,12 +715,7 @@ If any check fails, fix before preview.
 
 Show the complete task breakdown document.
 
-Use AskUserQuestion:
-- Question: "Write to `$JAAN_OUTPUTS_DIR/dev/backend/{slug}/task-breakdown.md`?"
-- Header: "Write"
-- Options:
-  - "Yes" — Write the file
-  - "No" — Cancel
+> "Here's the task breakdown preview. Write to `$JAAN_OUTPUTS_DIR/dev/backend/{slug}/task-breakdown.md`? [y/n]"
 
 ## Step 10: Write Output
 
@@ -748,18 +734,19 @@ If approved:
 
 ## Step 12: Capture Feedback
 
-Use AskUserQuestion:
-- Question: "Any feedback on the task breakdown?"
-- Header: "Feedback"
-- Options:
-  - "No" — All good, done
-  - "Fix now" — Update something in the breakdown
-  - "Learn" — Save lesson for future runs
-  - "Both" — Fix now AND save lesson
+> "Any feedback or improvements needed? [y/n]"
 
-- **Fix now**: Update the output file, re-preview, re-write
-- **Learn**: Run `/to-jaan-learn-add jaan-to-dev-be-task-breakdown "{feedback}"`
-- **Both**: Do both
+**If yes:**
+1. Ask: "What should be improved?"
+2. Offer options:
+   > "How should I handle this?
+   > [1] Fix now - Update the breakdown
+   > [2] Learn - Save for future runs
+   > [3] Both - Fix now AND save lesson"
+
+- **Option 1 - Fix now**: Update the output file, re-preview, re-write
+- **Option 2 - Learn**: Run `/to-jaan-learn-add jaan-to-dev-be-task-breakdown "{feedback}"`
+- **Option 3 - Both**: Do both
 
 ---
 

--- a/skills/jaan-to-dev-stack-detect/SKILL.md
+++ b/skills/jaan-to-dev-stack-detect/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Scans languages, frameworks, databases, infrastructure, CI/CD, and integrations.
   Auto-triggers on: detect stack, scan project, setup context, analyze tech
   Maps to: dev:stack-detect
-allowed-tools: Read, Glob, Grep, Bash(git remote:*), Bash(ls:*), Write($JAAN_CONTEXT_DIR/**), Edit($JAAN_CONTEXT_DIR/**), Write($JAAN_OUTPUTS_DIR/dev/**), AskUserQuestion
+allowed-tools: Read, Glob, Grep, Bash(git remote:*), Bash(ls:*), Write($JAAN_CONTEXT_DIR/**), Edit($JAAN_CONTEXT_DIR/**), Write($JAAN_OUTPUTS_DIR/dev/**)
 argument-hint: [optional-focus-area]
 ---
 
@@ -304,42 +304,26 @@ boundaries.md:   {action}
 config.md:       {action}
 ```
 
-## Step 11: AskUserQuestion — Merge Mode & File Selection
+## Step 11: Merge Mode & File Selection
 
-Use `AskUserQuestion` with two questions:
+Ask two questions:
 
 **Question 1 — Merge Mode:**
-```json
-{
-  "question": "How should detected values be applied to your context files?",
-  "header": "Merge Mode",
-  "options": [
-    { "label": "Auto-fill", "description": "Fill empty sections, skip customized ones" },
-    { "label": "Interactive", "description": "Fill empty, ask per customized section" },
-    { "label": "Overwrite", "description": "Replace all sections (shows full diff first)" },
-    { "label": "Cancel", "description": "Save report only, don't modify files" }
-  ],
-  "multiSelect": false
-}
-```
+> "How should detected values be applied to your context files?
+> [1] Auto-fill - Fill empty sections, skip customized ones
+> [2] Interactive - Fill empty, ask per customized section
+> [3] Overwrite - Replace all sections (shows full diff first)
+> [4] Cancel - Save report only, don't modify files"
 
 **Question 2 — File Selection:**
-```json
-{
-  "question": "Which context files should be updated?",
-  "header": "Target Files",
-  "options": [
-    { "label": "All detected", "description": "tech.md, integrations.md, boundaries.md, config.md" },
-    { "label": "tech.md only", "description": "Just the technology stack file" },
-    { "label": "tech + integrations", "description": "Stack and tools, skip boundaries/config" }
-  ],
-  "multiSelect": false
-}
-```
+> "Which context files should be updated?
+> [1] All detected - tech.md, integrations.md, boundaries.md, config.md
+> [2] tech.md only - Just the technology stack file
+> [3] tech + integrations - Stack and tools, skip boundaries/config"
 
 **If user selects "Cancel"**: Save detection report to `$JAAN_OUTPUTS_DIR/dev/stack-detect/` and stop.
 
-**Do NOT proceed to Phase 2 without explicit approval via AskUserQuestion.**
+**Do NOT proceed to Phase 2 without explicit approval.**
 
 ---
 
@@ -358,40 +342,22 @@ Based on merge mode selected in Step 11:
 
 ### Interactive mode
 1. Auto-fill all empty sections (same as above)
-2. For each **customized** section that has a different detected value, use `AskUserQuestion`:
+2. For each **customized** section that has a different detected value, ask:
 
-```json
-{
-  "question": "{section}: Current: {current_value} -> Detected: {detected_value} ({source}, {confidence}%)",
-  "header": "{short_name}",
-  "options": [
-    { "label": "Accept", "description": "Update to detected value" },
-    { "label": "Keep", "description": "Keep current value" },
-    { "label": "Skip all", "description": "Keep all remaining customized sections" }
-  ],
-  "multiSelect": false
-}
-```
-
-**Batch up to 4 section diffs per AskUserQuestion call** (API limit: max 4 questions per call).
+> "{section}: Current: {current_value} -> Detected: {detected_value} ({source}, {confidence}%)
+> [1] Accept - Update to detected value
+> [2] Keep - Keep current value
+> [3] Skip all - Keep all remaining customized sections"
 
 If user selects "Skip all" on any question, stop prompting and keep all remaining customized sections.
 
 ### Overwrite mode
 1. Show complete diff of proposed changes
-2. Use AskUserQuestion for final confirmation:
+2. Confirm with user:
 
-```json
-{
-  "question": "This will overwrite ALL sections in tech.md with detected values. Proceed?",
-  "header": "Confirm",
-  "options": [
-    { "label": "Overwrite", "description": "Replace all sections with detected values" },
-    { "label": "Cancel", "description": "Don't modify tech.md" }
-  ],
-  "multiSelect": false
-}
-```
+> "This will overwrite ALL sections in tech.md with detected values. Proceed?
+> [1] Overwrite - Replace all sections with detected values
+> [2] Cancel - Don't modify tech.md"
 
 3. If confirmed, write entire file with detected values
 
@@ -449,19 +415,11 @@ Auto-generate from detected structure:
 - Package files (`package.json`, `go.mod`, etc.)
 - Hidden directories (except `.claude/`)
 
-Show the proposed boundaries and use AskUserQuestion if they differ from current:
+Show the proposed boundaries and ask if they differ from current:
 
-```json
-{
-  "question": "Update safe write paths based on detected project structure?",
-  "header": "Boundaries",
-  "options": [
-    { "label": "Accept", "description": "Update denied locations list" },
-    { "label": "Keep", "description": "Keep current boundaries unchanged" }
-  ],
-  "multiSelect": false
-}
-```
+> "Update safe write paths based on detected project structure?
+> [1] Accept - Update denied locations list
+> [2] Keep - Keep current boundaries unchanged"
 
 ## Step 15: Update config.md
 
@@ -527,7 +485,7 @@ If yes:
 - [ ] Config files scanned across all detection layers
 - [ ] Confidence scores assigned to all detections
 - [ ] Detection report shown to user
-- [ ] User approved merge mode via AskUserQuestion
+- [ ] User approved merge mode
 - [ ] Context files updated per merge decisions
 - [ ] Detection report saved to outputs
 - [ ] Summary shown with manual review suggestions

--- a/skills/jaan-to-pm-prd-write/SKILL.md
+++ b/skills/jaan-to-pm-prd-write/SKILL.md
@@ -78,12 +78,7 @@ After receiving answers, mentally outline:
 
 Before generating the PRD, confirm with the user:
 
-Use AskUserQuestion to ask the user:
-- Question: "Ready to generate the PRD for '{initiative}'?"
-- Header: "Proceed"
-- Options:
-  - "Yes" — Generate the PRD
-  - "No" — Cancel and start over
+> "I have all the information needed. Ready to generate the PRD for '{initiative}'? [y/n]"
 
 **Do NOT proceed to Phase 2 without explicit approval.**
 
@@ -133,12 +128,7 @@ If any check fails, revise before preview.
 
 ## Step 5: Preview & Approval
 Show the complete PRD and ask:
-Use AskUserQuestion:
-- Question: "Write PRD to `$JAAN_OUTPUTS_DIR/pm/{slug}/prd.md`?"
-- Header: "Write"
-- Options:
-  - "Yes" — Write the file
-  - "No" — Cancel
+> "Here's the PRD preview. Write to `$JAAN_OUTPUTS_DIR/pm/{slug}/prd.md`? [y/n]"
 
 ## Step 6: Write Output
 If approved:
@@ -179,28 +169,32 @@ Gherkin acceptance criteria, and edge case mapping.
 
 ## Step 8: Capture Feedback
 
-Use AskUserQuestion:
-- Question: "Any feedback on the PRD?"
-- Header: "Feedback"
-- Options:
-  - "No" — All good, done
-  - "Fix now" — Update this PRD
-  - "Learn" — Save lesson for future PRDs
-  - "Both" — Fix now AND save lesson
+After PRD is written, ask:
+> "Any feedback or improvements needed? [y/n]"
 
-**Fix now:**
-- Ask: "What should be improved?" (text response)
+**If yes:**
+1. Ask: "What should be improved?"
+2. Offer options:
+   > "How should I handle this?
+   > [1] Fix now - Update this PRD
+   > [2] Learn - Save for future PRDs
+   > [3] Both - Fix now AND save lesson"
+
+**Option 1 - Fix now:**
 - Apply the feedback to the current PRD
 - Re-run Step 5 (Preview & Approval) with updated content
 - Write the updated PRD
 
-**Learn:**
+**Option 2 - Learn for future:**
 - Run: `/to-jaan-learn-add jaan-to-pm-prd-write "{feedback}"`
 - Follow /to-jaan-learn-add workflow (categorize → preview → commit)
 
-**Both:**
-- First: Apply fix to current PRD
-- Then: Run `/to-jaan-learn-add`
+**Option 3 - Both:**
+- First: Apply fix to current PRD (Option 1)
+- Then: Run `/to-jaan-learn-add` (Option 2)
+
+**If no:**
+- PRD workflow complete
 
 ---
 

--- a/skills/jaan-to-pm-research-about/SKILL.md
+++ b/skills/jaan-to-pm-research-about/SKILL.md
@@ -102,43 +102,32 @@ If ambiguous, default to `ai-workflow` for AI topics or `dev` for technical topi
 
 **If topic is unclear or broad, ask 3-5 clarifying questions.**
 
-Use a single AskUserQuestion call with these 4 questions:
+Each question offers **3 options + 1 recommendation**:
 
-1. Question: "What's your primary goal?"
-   Header: "Goal"
-   Options:
-   - "Learning" — Understand fundamentals and concepts
-   - "Implementation" — Ready-to-use patterns and code
-   - "Comparison" — Evaluate alternatives side by side
-
-2. Question: "What depth level?"
-   Header: "Depth"
-   Options:
-   - "Overview" — High-level concepts only
-   - "Intermediate" — Patterns and practices (recommended)
-   - "Advanced" — Internals and edge cases
-
-3. Question: "What's the context?"
-   Header: "Context"
-   Options:
-   - "New project" — Starting fresh
-   - "Existing codebase" — Migration or integration
-   - "General knowledge" — No specific project
-
-4. Question: "Which aspect matters most?"
-   Header: "Aspect"
-   Options:
-   - "Performance" — Speed, efficiency, optimization
-   - "Developer experience" — Ergonomics, tooling, DX
-   - "Ecosystem" — Community, libraries, support
-
-Then use a separate AskUserQuestion:
-- Question: "Include comparisons with alternatives?"
-- Header: "Compare"
-- Options:
-  - "Yes" — Full comparison with {X} and {Y}
-  - "Brief" — Brief mentions only
-  - "No" — Skip comparisons
+> **Q1: What's your primary goal?**
+> - [A] Learning fundamentals ← *Recommended for beginners*
+> - [B] Implementation guide
+> - [C] Comparison with alternatives
+>
+> **Q2: What depth level?**
+> - [A] Overview (high-level concepts)
+> - [B] Intermediate (patterns & practices) ← *Recommended*
+> - [C] Advanced (internals & edge cases)
+>
+> **Q3: What's the context?**
+> - [A] New project
+> - [B] Existing codebase ← *Recommended if migration mentioned*
+> - [C] General knowledge
+>
+> **Q4: Which aspect matters most?**
+> - [A] Performance
+> - [B] Developer experience ← *Recommended*
+> - [C] Ecosystem & community
+>
+> **Q5: Include comparisons?**
+> - [A] Yes, with {X} and {Y} ← *Recommended*
+> - [B] Brief mentions only
+> - [C] No comparisons needed
 
 **Skip questions if:**
 - Topic is already specific (e.g., "Claude Code hooks for pre-commit validation")
@@ -151,19 +140,17 @@ Then use a separate AskUserQuestion:
 
 ## Step 1.5: Choose Research Size
 
-Use AskUserQuestion:
-- Question: "How comprehensive should the research be?"
-- Header: "Size"
-- Options:
-  - "Quick (~20 sources)" — 3 agents, best for simple topics or quick overviews
-  - "Standard (~60 sources)" — 7 agents, solid research (recommended)
-  - "Deep (~100 sources)" — 10 agents, comprehensive coverage
-  - "Other" — Specify custom size (Extensive ~200 or Exhaustive ~500)
+> **How comprehensive should the research be?**
+>
+> | Size | Sources | Agents | Best For |
+> |------|---------|--------|----------|
+> | [A] Quick (20) | ~20 sources | 3 agents | Quick overview ← *Recommended for simple topics* |
+> | [B] Standard (60) | ~60 sources | 7 agents | Solid research ← *Recommended* |
+> | [C] Deep (100) | ~100 sources | 10 agents | Comprehensive coverage |
+> | [D] Extensive (200) | ~200 sources | 14 agents | In-depth analysis |
+> | [E] Exhaustive (500) | ~500 sources | 29 agents | Maximum coverage |
 
-If "Other" selected, ask (text response expected):
-> "How many sources? Options: 200 (Extensive, 14 agents) or 500 (Exhaustive, 29 agents)"
-
-**Default**: Standard (60) if user doesn't specify.
+**Default**: Standard (60) if user doesn't specify or just presses enter.
 
 **Agent Capacity:**
 ```
@@ -195,15 +182,15 @@ If "Other" selected, ask (text response expected):
 
 ## Step 1.6: Choose Approval Mode
 
-Use AskUserQuestion:
-- Question: "How much oversight do you want during research?"
-- Header: "Oversight"
-- Options:
-  - "Auto" — Run all waves automatically, show final document only (fastest)
-  - "Summary" — Brief progress after each wave, no approval needed
-  - "Interactive" — Ask for approval at each major step (default)
+> **How much oversight do you want?**
+>
+> | Mode | Description |
+> |------|-------------|
+> | [A] Auto | Run all waves automatically, show final document only ← *Faster* |
+> | [B] Summary | Show brief progress after each wave, no approval needed |
+> | [C] Interactive | Ask for approval at each major step ← *Default* |
 
-**Default**: Interactive if user doesn't specify.
+**Default**: Interactive (C) if user doesn't specify.
 
 **Mode Behaviors:**
 
@@ -692,12 +679,7 @@ WILL CREATE
 □ Update jaan-to/outputs/research/README.md
 ```
 
-Use AskUserQuestion:
-- Question: "Generate full research document?"
-- Header: "Generate"
-- Options:
-  - "Yes" — Proceed with document generation
-  - "No" — Cancel
+> "Generate full research document? [y/n]"
 
 **Do NOT proceed to Phase 4 without explicit approval.**
 
@@ -738,12 +720,7 @@ If any check fails, revise before preview.
 
 **If `{approval_mode}` = Interactive:**
 - Show complete document
-- Use AskUserQuestion:
-  - Question: "Write to `$JAAN_OUTPUTS_DIR/research/{filename}`?"
-  - Header: "Write"
-  - Options:
-    - "Yes" — Write the research document
-    - "No" — Cancel
+- Ask: > "Write to `$JAAN_OUTPUTS_DIR/research/{filename}`? [y/n]"
 
 ## Step 10: Write Output
 
@@ -813,18 +790,10 @@ README.md updated with new entry.
 
 ## Step 14: Capture Feedback
 
-Use AskUserQuestion:
-- Question: "Any feedback on this research?"
-- Header: "Feedback"
-- Options:
-  - "No" — All good, done
-  - "Fix now" — Update this output
-  - "Learn" — Save lesson for future runs
-  - "Both" — Fix now AND save lesson
+> "Any feedback on this research? [y/n]"
 
-- **Fix now**: Update output, re-preview, re-write
-- **Learn**: Run `/to-jaan-learn-add jaan-to-pm-research-about "{feedback}"`
-- **Both**: Do both
+If yes:
+- Run `/to-jaan-learn-add jaan-to-pm-research-about "{feedback}"`
 
 ---
 
@@ -892,12 +861,7 @@ WILL MODIFY:
 □ jaan-to/outputs/research/{filename} (if URL: create new file)
 ```
 
-Use AskUserQuestion:
-- Question: "Proceed with adding to index?"
-- Header: "Add"
-- Options:
-  - "Yes" — Add to research index
-  - "No" — Cancel
+> "Proceed with adding to index? [y/n]"
 
 Do NOT proceed without approval.
 
@@ -954,18 +918,9 @@ Files modified:
 - jaan-to/outputs/research/{filename} (if URL)
 ```
 
-Use AskUserQuestion:
-- Question: "Any feedback on this indexing?"
-- Header: "Feedback"
-- Options:
-  - "No" — All good, done
-  - "Fix now" — Update the index entry
-  - "Learn" — Save lesson for future runs
-  - "Both" — Fix now AND save lesson
+> "Any feedback? [y/n]"
 
-- **Fix now**: Update index entry
-- **Learn**: Run `/to-jaan-learn-add jaan-to-pm-research-about "{feedback}"`
-- **Both**: Do both
+If yes: Run `/to-jaan-learn-add jaan-to-pm-research-about "{feedback}"`
 
 ---
 

--- a/skills/jaan-to-pm-story-write/SKILL.md
+++ b/skills/jaan-to-pm-story-write/SKILL.md
@@ -89,14 +89,9 @@ Analyze `$ARGUMENTS` format:
 > "I understand you want to create a story about:
 > - **Feature**: {feature}
 > - **Persona**: {persona}
-> - **Goal**: {goal}"
-
-Use AskUserQuestion:
-- Question: "Is this correct?"
-- Header: "Parse"
-- Options:
-  - "Yes" — Proceed with these
-  - "No" — Let me clarify
+> - **Goal**: {goal}
+>
+> Is this correct? [y/n]"
 
 If "n", ask what needs clarification and reparse.
 
@@ -244,17 +239,11 @@ Categories addressed: {comma-separated list from Step 2}
 Minimum ACs required: {number}
 ```
 
-Use AskUserQuestion:
-- Question: "Ready to generate the full user story?"
-- Header: "Proceed"
-- Options:
-  - "Yes" — Generate the story
-  - "No" — Cancel
-  - "Revise" — Let me change the plan first
+> "Ready to generate the full user story? [y/n/revise]"
 
 **Do NOT proceed to Phase 2 without explicit approval.**
 
-If "Revise", ask what needs to change and return to the relevant Phase 1 step.
+If "revise", ask what needs to change and return to the relevant Phase 1 step.
 
 ---
 
@@ -468,17 +457,14 @@ Verify each acceptance criterion:
 > **Pattern 6: Cross-Cutting Concerns** - Defer performance/security/scale
 > Example: Search works correctly now, fast search later, concurrent search later
 >
-Use AskUserQuestion:
-- Question: "Story may be too large. How to proceed?"
-- Header: "Split"
-- Options:
-  - "Split" — Split using suggested pattern
-  - "Refine" — Keep as single story but refine scope
-  - "Proceed" — Keep as-is (flag as >5 points)
+> Would you like to:
+> [1] Split now using pattern #{n}
+> [2] Refine and keep as single story
+> [3] Proceed as-is (will flag as >5 points)"
 
-If "Split", guide them through splitting and restart from Step 3 with split stories.
-If "Refine", ask what to refine and return to Step 4.
-If "Proceed", add note to story: "Note: Estimated >5 points—consider splitting during refinement."
+If user chooses [1], guide them through splitting and restart from Step 3 with split stories.
+If user chooses [2], ask what to refine and return to Step 4.
+If user chooses [3], add note to story: "Note: Estimated >5 points—consider splitting during refinement."
 
 ## Step 6: Preview & Approval
 
@@ -492,12 +478,7 @@ Show complete story in markdown format:
 {complete story content with all 9 sections}
 ```
 
-Use AskUserQuestion:
-- Question: "Write story to `$JAAN_OUTPUTS_DIR/pm/stories/{slug}/stories.md`?"
-- Header: "Write"
-- Options:
-  - "Yes" — Write the file
-  - "No" — Cancel and revise
+> "📋 Preview complete. Write to `$JAAN_OUTPUTS_DIR/pm/stories/{slug}/stories.md`? [y/n]"
 
 If "n", ask what needs revision and return to Step 4.
 
@@ -541,28 +522,32 @@ Also provide tool export formats (from research Section 7):
 
 ## Step 8: Capture Feedback
 
-Use AskUserQuestion:
-- Question: "Any feedback on the story?"
-- Header: "Feedback"
-- Options:
-  - "No" — All good, done
-  - "Fix now" — Update this story
-  - "Learn" — Save lesson for future stories
-  - "Both" — Fix now AND save lesson
+After story is written, ask:
+> "Any feedback or improvements for this story? [y/n]"
 
-**Fix now:**
-- Ask: "What should be improved?" (text response)
+**If yes:**
+1. Ask: "What should be improved?"
+2. Offer options:
+   > "How should I handle this feedback?
+   > [1] Fix now - Update this story
+   > [2] Learn - Save for future stories via /to-jaan-learn-add
+   > [3] Both - Fix now AND save lesson"
+
+**Option 1 - Fix now:**
 - Apply the feedback to the current story
 - Re-run Step 6 (Preview & Approval) with updated content
 - Re-write the updated story
 
-**Learn:**
+**Option 2 - Learn for future:**
 - Run: `/to-jaan-learn-add jaan-to-pm-story-write "{feedback}"`
 - Let the learn-add skill categorize and save the lesson
 
-**Both:**
-- First: Apply fix to current story
+**Option 3 - Both:**
+- First: Apply fix to current story (Option 1)
 - Then: Run `/to-jaan-learn-add jaan-to-pm-story-write "{feedback}"`
+
+**If no:**
+- Story workflow complete
 
 ---
 

--- a/skills/jaan-to-ux-heatmap-analyze/SKILL.md
+++ b/skills/jaan-to-ux-heatmap-analyze/SKILL.md
@@ -67,13 +67,11 @@ If column headers contain `timestamp`, `session_id`, `x_coordinate`, `y_coordina
 - Parse all columns, note available fields
 
 **Format Unknown:**
-If neither pattern matches, use AskUserQuestion:
-- Question: "Cannot auto-detect CSV format. What type of data is this?"
-- Header: "Format"
-- Options:
-  - "Aggregated" — Ranked elements with click counts (e.g., analytics tool export)
-  - "Raw events" — Individual click events with coordinates and timestamps
-  - "Other" — Let me describe the format
+If neither pattern matches:
+> "Cannot auto-detect CSV format. What type of data is this?
+> [1] Aggregated - Ranked elements with click counts (e.g., analytics tool export)
+> [2] Raw events - Individual click events with coordinates and timestamps
+> [3] Other - Let me describe the format"
 
 For each file, validate:
 - CSV is parseable with consistent columns
@@ -121,26 +119,20 @@ State clearly what analysis IS and IS NOT possible:
 
 ## Step 3: Clarify Analysis Goal
 
-Use AskUserQuestion:
-- Question: "What is the primary question this analysis should answer?"
-- Header: "Goal"
-- Options:
-  - "Find friction" — Identify frustration points and conversion barriers
-  - "Optimize CTA" — Evaluate button/link placement and visibility
-  - "Compare" — Desktop vs mobile or behavior segment differences
-  - "Other" — Let me describe my specific question
+> "What is the primary question this analysis should answer?
+> [1] Find friction - Identify frustration points and conversion barriers
+> [2] Optimize CTA - Evaluate button/link placement and visibility
+> [3] Compare - Desktop vs mobile or behavior segment differences
+> [4] Other - Let me describe my specific question"
 
 If "Other" selected, ask: "What specific question should this analysis answer?"
 
 If multiple CSV files provided (different devices or behavior segments), ask:
 
-Use AskUserQuestion:
-- Question: "You provided {N} CSV files. How should they be analyzed?"
-- Header: "Multi-file"
-- Options:
-  - "Compare" — Side-by-side comparison across files
-  - "Separate" — Independent analysis for each file
-  - "Combined" — Merge all data into single analysis
+> "You provided {N} CSV files. How should they be analyzed?
+> [1] Compare - Side-by-side comparison across files
+> [2] Separate - Independent analysis for each file
+> [3] Combined - Merge all data into single analysis"
 
 ## Step 4: Visual Analysis (Screenshots)
 
@@ -330,13 +322,7 @@ REPORT SECTIONS:
 ════════════════════════════════════════
 ```
 
-Use AskUserQuestion:
-- Question: "Proceed with full report generation?"
-- Header: "Proceed"
-- Options:
-  - "Yes" — Generate the report
-  - "Edit" — Let me adjust the analysis focus
-  - "No" — Cancel
+> "Proceed with full report generation? [y/edit/n]"
 
 **Do NOT proceed to Phase 2 without explicit approval.**
 
@@ -392,12 +378,7 @@ If any check fails, revise the report before preview.
 
 Show the complete report in conversation.
 
-Use AskUserQuestion:
-- Question: "Write report to `$JAAN_OUTPUTS_DIR/ux/heatmap/{slug}/report.md`?"
-- Header: "Write"
-- Options:
-  - "Yes" — Write the file
-  - "No" — Cancel
+> "Here's the report preview. Write to `$JAAN_OUTPUTS_DIR/ux/heatmap/{slug}/report.md`? [y/n]"
 
 ## Step 12: Write Output
 
@@ -411,18 +392,19 @@ If approved:
 
 ## Step 13: Capture Feedback
 
-Use AskUserQuestion:
-- Question: "Any feedback on the heatmap analysis?"
-- Header: "Feedback"
-- Options:
-  - "No" — All good, done
-  - "Fix now" — Update this report
-  - "Learn" — Save lesson for future analyses
-  - "Both" — Fix now AND save lesson
+> "Any feedback or improvements needed? [y/n]"
 
-- **Fix now**: Revise report, re-preview, re-write
-- **Learn**: Run `/to-jaan-learn-add jaan-to-ux-heatmap-analyze "{feedback}"`
-- **Both**: Do both
+**If yes:**
+1. Ask: "What should be improved?"
+2. Offer options:
+   > "How should I handle this?
+   > [1] Fix now - Update this report
+   > [2] Learn - Save for future analyses
+   > [3] Both - Fix now AND save lesson"
+
+- **Option 1 - Fix now**: Revise report, re-preview, re-write
+- **Option 2 - Learn**: Run `/to-jaan-learn-add jaan-to-ux-heatmap-analyze "{feedback}"`
+- **Option 3 - Both**: Do both
 
 ---
 

--- a/skills/to-jaan-docs-create/SKILL.md
+++ b/skills/to-jaan-docs-create/SKILL.md
@@ -69,12 +69,7 @@ Analyze user input to understand their actual need:
 
 **If input is clear** (high confidence):
 - Auto-select type
-- Use AskUserQuestion:
-  - Question: "I recommend **{type}** documentation. {reasoning}."
-  - Header: "Type"
-  - Options:
-    - "Yes" — Use recommended type
-    - "Other" — Let me specify a different type
+- Confirm: "I recommend **{type}** documentation for this. Here's why: {reasoning}. Proceed? [y/n/other]"
 
 **If input is unclear** (ambiguous signals):
 - Ask up to 5 smart clarifying questions tailored to the specific ambiguity
@@ -111,17 +106,7 @@ After determining type, ask for name if not provided:
 | concept | `docs/{name}.md` |
 | index | `docs/{section}/README.md` |
 
-For skill type, use AskUserQuestion:
-- Question: "Which role does this skill belong to?"
-- Header: "Role"
-- Options:
-  - "pm" — Product Management
-  - "dev" — Development / Engineering
-  - "data" — Data / Analytics
-  - "Other" — Specify role (qa, ux, core, devops, etc.)
-
-If "Other" selected, ask (text response expected):
-> "Which role? (qa, ux, core, devops, etc.)"
+For skill type, ask: "Which role? [pm/dev/qa/ux/data/core]"
 
 ## Step 3: Check for Duplicates
 
@@ -131,13 +116,8 @@ Glob: docs/**/*{name}*.md
 Grep: "{name}" in docs/
 ```
 
-If potential duplicate found, use AskUserQuestion:
-- Question: "Similar doc exists: `{path}`. What would you like to do?"
-- Header: "Duplicate"
-- Options:
-  - "Proceed" — Create new doc anyway
-  - "Update" — Update existing doc instead
-  - "Cancel" — Stop, don't create
+If potential duplicate found:
+> "Similar doc exists: `{path}`. Options: [proceed/update-existing/cancel]"
 
 ## Step 4: Read STYLE.md
 
@@ -185,15 +165,9 @@ Ready to Create Documentation
 
 ## Content Preview:
 {first 20 lines of content}
-```
 
-Use AskUserQuestion:
-- Question: "Proceed with documentation creation?"
-- Header: "Proceed"
-- Options:
-  - "Yes" — Generate the documentation
-  - "No" — Cancel
-  - "Edit" — Let me revise the content first
+Proceed? [y/n/edit]
+```
 
 **Do NOT proceed without explicit approval.**
 
@@ -241,12 +215,8 @@ If validation fails, fix before proceeding.
 
 ## Step 10: Preview & Write
 
-Show full preview and use AskUserQuestion:
-- Question: "Write to `{path}`?"
-- Header: "Write"
-- Options:
-  - "Yes" — Write the documentation file
-  - "No" — Cancel
+Show full preview and ask:
+> "Write to `{path}`? [y/n]"
 
 If approved, write file.
 
@@ -269,16 +239,11 @@ Show confirmation:
 
 **File:** {path}
 **Commit:** {hash}
+
+Run `/to-jaan-docs-update` to check related docs? [y/n]
 ```
 
-Use AskUserQuestion:
-- Question: "Run `/to-jaan-docs-update` to check related docs?"
-- Header: "Follow-up"
-- Options:
-  - "Yes" — Run quick audit on related docs
-  - "No" — Done, skip follow-up
-
-If "Yes", run `/to-jaan-docs-update --quick` for related docs.
+If yes, suggest running `/to-jaan-docs-update --quick` for related docs.
 
 ---
 

--- a/skills/to-jaan-docs-update/SKILL.md
+++ b/skills/to-jaan-docs-update/SKILL.md
@@ -147,23 +147,19 @@ If code exists but doc doesn't → Flag as MISSING
 
 ---
 
+What would you like to do?
+[1] Review stale docs one by one
+[2] Full audit (check everything)
+[3] Quick fix (update dates only)
+[4] Exit
 ```
-
-Use AskUserQuestion:
-- Question: "What would you like to do?"
-- Header: "Action"
-- Options:
-  - "Review" — Review stale docs one by one
-  - "Full audit" — Check everything in detail
-  - "Quick fix" — Update dates only
-  - "Exit" — Stop here
 
 **HARD STOP:** Wait for user choice.
 
-**Review:** For each stale doc, show side-by-side what changed in code, ask what to update.
-**Full audit:** Continue to PHASE 1 (full audit).
-**Quick fix:** Just update `updated_date` in stale docs.
-**Exit:** Stop.
+**Option 1:** For each stale doc, show side-by-side what changed in code, ask what to update.
+**Option 2:** Continue to PHASE 1 (full audit).
+**Option 3:** Just update `updated_date` in stale docs.
+**Option 4:** Stop.
 
 ---
 
@@ -215,15 +211,7 @@ Grep: "^>" in docs/**/*.md
 - Missing tagline: X files
 - Potential issues: X files
 
-```
-
-Use AskUserQuestion:
-- Question: "Proceed with full audit?"
-- Header: "Audit"
-- Options:
-  - "Yes" — Full audit of all docs
-  - "No" — Stop here
-  - "Quick fixes" — Fix frontmatter/dates only
+Proceed with full audit? [yes/no/quick-fixes-only]
 ```
 
 **If `--quick`:** Stop here.
@@ -331,15 +319,8 @@ Show audit report:
 
 ---
 
+Apply fixes? [yes/no/selective]
 ```
-
-Use AskUserQuestion:
-- Question: "Apply fixes from audit?"
-- Header: "Fix"
-- Options:
-  - "Yes" — Apply all fixes
-  - "No" — Report only
-  - "Selective" — Choose which fixes to apply
 
 **If `--check-only`:** Stop here.
 **Do NOT proceed without explicit approval.**
@@ -409,12 +390,7 @@ Update any references to moved file.
 
 ## Step 4.1: Commit Changes
 
-Use AskUserQuestion:
-- Question: "Commit documentation updates?"
-- Header: "Commit"
-- Options:
-  - "Yes" — Stage and commit changes
-  - "No" — Keep changes uncommitted
+Ask: "Commit documentation updates? [y/n]"
 
 If yes:
 ```bash

--- a/skills/to-jaan-learn-add/SKILL.md
+++ b/skills/to-jaan-learn-add/SKILL.md
@@ -67,14 +67,7 @@ Detect category from lesson keywords:
 | Workflow | workflow, process, step, order, "before/after" |
 | Common Mistakes | avoid, mistake, wrong, don't, never, "should not" |
 
-If unclear, use AskUserQuestion:
-- Question: "Which category fits this lesson?"
-- Header: "Category"
-- Options:
-  - "Questions" — Better questions to ask during gathering
-  - "Edge Cases" — Special cases to check and handle
-  - "Workflow" — Process improvements
-  - "Mistakes" — Things to avoid
+If unclear, ask: "Which category? [questions/edge-cases/workflow/mistakes]"
 
 ## Step 4: Read Current LEARN.md
 
@@ -98,15 +91,8 @@ Preview:
 - {existing lessons...}
 - {new lesson}  <-- NEW
 
+Confirm? [y/n/edit]
 ```
-
-Use AskUserQuestion:
-- Question: "Add this lesson?"
-- Header: "Confirm"
-- Options:
-  - "Yes" — Add the lesson
-  - "No" — Cancel
-  - "Edit" — Let me revise the lesson
 
 **Do NOT proceed without explicit approval.**
 
@@ -160,12 +146,10 @@ Lesson Added
 
 ## Step 7: Offer to Commit
 
-Use AskUserQuestion:
-- Question: "Commit this lesson?"
-- Header: "Commit"
-- Options:
-  - "Yes" — Stage and commit
-  - "No" — Save locally without committing
+Ask user:
+```
+Commit this lesson? [y/n]
+```
 
 **If confirmed:**
 1. Stage: `git add {file_path}`

--- a/skills/to-jaan-roadmap-add/SKILL.md
+++ b/skills/to-jaan-roadmap-add/SKILL.md
@@ -57,13 +57,8 @@ Extract keywords from the task description and search:
 grep -i "<keyword>" jaan-to/roadmap.md
 ```
 
-If potential duplicate found, use AskUserQuestion:
-- Question: "Similar task exists: '{existing}' in Phase {n}. Proceed?"
-- Header: "Duplicate"
-- Options:
-  - "Yes" — Create a new task anyway
-  - "No" — Cancel
-  - "Merge" — Merge with existing task
+If potential duplicate found:
+> "Similar task exists: '{existing}' in Phase {n}. Proceed anyway? [y/n/merge]"
 
 ## Step 3: Phase Detection
 
@@ -80,24 +75,11 @@ Determine which phase the task belongs to:
 | Tests, polish, export | Phase 7 |
 | Distribution, plugin | Phase 8 |
 
-Use AskUserQuestion:
-- Question: "Add to Phase {suggested}?"
-- Header: "Phase"
-- Options:
-  - "Yes" — Add to suggested phase
-  - "Different" — Let me specify a different phase
-
-If "Different", ask (text response expected):
-> "Which phase? (1-8)"
+Ask: "Add to Phase {suggested}? Or specify different phase (1-8)"
 
 ## Step 4: Detail Check
 
-Use AskUserQuestion:
-- Question: "Does this need a detailed task doc in `tasks/`?"
-- Header: "Detail"
-- Options:
-  - "Yes" — Create a tasks/{slug}.md file
-  - "No" — Inline task only
+Ask: "Does this need a detailed task doc in `tasks/`? [y/n]"
 
 ---
 
@@ -111,15 +93,8 @@ Ready to Add
 **Task:** `- [ ] {formatted task}`
 **Detail doc:** {yes/no - tasks/{slug}.md}
 
+Confirm? [y/n/edit]
 ```
-
-Use AskUserQuestion:
-- Question: "Add this task to the roadmap?"
-- Header: "Add"
-- Options:
-  - "Yes" — Add the task
-  - "No" — Cancel
-  - "Edit" — Let me revise it
 
 **Do NOT proceed without explicit approval.**
 
@@ -156,14 +131,7 @@ Task Added
 **Task:** - [ ] {task}
 **Commit:** {hash}
 
-```
-
-Use AskUserQuestion:
-- Question: "Push to remote?"
-- Header: "Push"
-- Options:
-  - "Yes" — Push to origin
-  - "No" — Keep local only
+Push to remote? [y/n]
 ```
 
 ---

--- a/skills/to-jaan-skill-create/SKILL.md
+++ b/skills/to-jaan-skill-create/SKILL.md
@@ -63,24 +63,13 @@ Before any creation, check for existing skills:
 
 3. **Decision tree**:
    - **Exact match exists**: "Skill '{name}' already does this. Use: `/{command}` [show example]"
-   - **>70% overlap**: Use AskUserQuestion:
-     - Question: "'{name}' is similar ({n}% overlap). Update it instead?"
-     - Header: "Overlap"
-     - Options:
-       - "Update" — Invoke `/to-jaan-skill-update {name}`
-       - "New" — Continue creating a new skill
+   - **>70% overlap**: "'{name}' is similar ({n}% overlap). Update it instead? [update/new]"
      - If update: Invoke `/to-jaan-skill-update {name}`
      - If new: Continue with creation
    - **<70% overlap**: Continue with creation
 
 4. **Fast-track option** for simple skills:
-
-   Use AskUserQuestion:
-   - Question: "This seems straightforward. Create minimal skill directly?"
-   - Header: "Fast-track"
-   - Options:
-     - "Yes" — Create minimal skill without full wizard
-     - "Wizard" — Go through full step-by-step process
+   > "This seems straightforward. Create minimal skill directly? [y/wizard]"
 
    Skip wizard for:
    - Single-purpose skills with obvious structure
@@ -219,13 +208,8 @@ Show research-based suggestions, then ask:
 2. "What files/outputs does it produce?"
    - [Suggested from templates]: {format} file with {sections}
 
-3. Use AskUserQuestion for output format:
-   - Question: "What output format?"
-   - Header: "Format"
-   - Options:
-     - "Markdown" — Standard .md output file
-     - "JSON" — Structured .json output file
-     - "Both" — Markdown + JSON output
+3. "What format? (markdown/json/both)"
+   - Determines template.md creation
 
 ## Step 5: Questions, Quality & Done
 
@@ -235,23 +219,13 @@ Present research-based suggestions, let user accept/modify/add:
    - [Pre-filled from research]:
      - {research_question1}
      - {research_question2}
-   - Use AskUserQuestion:
-     - Question: "Accept these questions or edit them?"
-     - Header: "Questions"
-     - Options:
-       - "Accept" — Use as-is
-       - "Edit" — Let me modify the list
+   - "Add more or modify? [accept/edit]"
 
 2. "What quality checks before writing?"
    - [Pre-filled from research]:
      - [ ] {research_check1}
      - [ ] {research_check2}
-   - Use AskUserQuestion:
-     - Question: "Accept these quality checks or edit them?"
-     - Header: "Checks"
-     - Options:
-       - "Accept" — Use as-is
-       - "Edit" — Let me modify the list
+   - "Add more or modify? [accept/edit]"
 
 3. "What defines 'done' for this skill?"
    - [Suggested]:
@@ -291,13 +265,7 @@ WILL ALSO
 □ Commit to branch skill/{name}
 ```
 
-Use AskUserQuestion to ask the user:
-- Question: "Create this skill?"
-- Header: "Create"
-- Options:
-  - "Yes" — Proceed with skill generation
-  - "No" — Cancel and start over
-  - "Edit" — Let me revise the plan first
+> "Create this skill? [y/n/edit]"
 
 **Do NOT proceed to Phase 2 without explicit approval.**
 
@@ -328,21 +296,10 @@ Use template from `$JAAN_TEMPLATES_DIR/to-jaan-skill-create.template.md`:
    - Context Files from gathered info
    - Input handling from Step 4
    - Phase 1 questions from Step 5
-   - HARD STOP section (**must use AskUserQuestion** — not text prompt)
+   - HARD STOP section
    - Phase 2 generation steps
-   - Preview & Approval step (**must use AskUserQuestion** — not text prompt)
    - Quality checks from Step 5
-   - Feedback section (**must use AskUserQuestion** with 3-4 options)
    - Definition of Done from Step 5
-
-3. **AskUserQuestion rules for generated skills:**
-   - For each question from Step 5: determine if it has fixed options (2-4 → AskUserQuestion) or needs free text (→ text prompt)
-   - HARD STOP: always AskUserQuestion with Yes/No/Edit options
-   - Preview approval: always AskUserQuestion with Yes/No options
-   - Feedback capture: always AskUserQuestion with No/Fix now/Learn/Both options
-   - Menus with 5+ options: keep as text or split into 2-step AskUserQuestion
-   - Open-ended questions: always text prompt
-   - See `docs/extending/create-skill.md` "User Interaction Patterns" section for full reference
 
 ## Step 8: Generate LEARN.md (Plugin Source)
 
@@ -411,14 +368,6 @@ Check against `jaan-to/docs/create-skill.md`:
 - [ ] Has `# PHASE 2: Generation`
 - [ ] Has `## Definition of Done`
 
-**AskUserQuestion Usage**:
-- [ ] HARD STOP uses AskUserQuestion (not text prompt)
-- [ ] Preview approval uses AskUserQuestion (not text prompt)
-- [ ] Feedback section uses AskUserQuestion with 3-4 options
-- [ ] Structured choices (2-4 options) use AskUserQuestion
-- [ ] Open-ended questions use text prompts
-- [ ] No `> "...? [y/n]"` patterns remain for structured choices
-
 **Trust**:
 - [ ] Tool permissions are sandboxed (not `Write(*)`)
 - [ ] Has human approval checks
@@ -432,12 +381,7 @@ Show complete content of:
 2. LEARN.md
 3. template.md (if created)
 
-Use AskUserQuestion:
-- Question: "Write these files?"
-- Header: "Write"
-- Options:
-  - "Yes" — Write all files
-  - "No" — Cancel
+> "Write these files? [y/n]"
 
 ## Step 12: Write Files (v3.0.0-Compliant)
 
@@ -538,12 +482,8 @@ Standard tech.md anchors:
 
 1. Generate slug from title: lowercase, hyphens, no special chars
 2. Construct path: `$JAAN_OUTPUTS_DIR/{role}/{domain}/{slug}/`
-3. Ask for approval using AskUserQuestion:
-   - Question: "Write to `$JAAN_OUTPUTS_DIR/{role}/{domain}/{slug}/{filename}`?"
-   - Header: "Write"
-   - Options:
-     - "Yes" — Write the file
-     - "No" — Cancel
+3. Ask for approval:
+   > "Write to `$JAAN_OUTPUTS_DIR/{role}/{domain}/{slug}/{filename}`? [y/n]"
 4. If approved:
    - Create directory: `$JAAN_OUTPUTS_DIR/{role}/{domain}/{slug}/`
    - Write file: `$JAAN_OUTPUTS_DIR/{role}/{domain}/{slug}/{filename}`
@@ -791,12 +731,7 @@ This checks for:
 > /jaan-to-pm-prd-write "Add user authentication with OAuth support"
 > ```
 >
-Use AskUserQuestion:
-- Question: "Did the skill work correctly?"
-- Header: "Test"
-- Options:
-  - "Yes" — Works as expected
-  - "No" — Has issues to fix
+> "Did it work correctly? [y/n]"
 
 If issues:
 1. Help debug the problem
@@ -806,12 +741,8 @@ If issues:
 
 ## Step 19: Create Pull Request
 
-When user confirms working, use AskUserQuestion:
-- Question: "Create pull request to merge to main?"
-- Header: "PR"
-- Options:
-  - "Yes" — Push branch and create PR
-  - "No" — Keep branch, merge manually later
+When user confirms working:
+> "Create pull request to merge to main? [y/n]"
 
 If yes:
 ```bash
@@ -853,18 +784,10 @@ If no:
 
 ## Step 20: Capture Feedback
 
-Use AskUserQuestion:
-- Question: "Any feedback on the skill creation process?"
-- Header: "Feedback"
-- Options:
-  - "No" — All good, done
-  - "Fix now" — Update something in the skill
-  - "Learn" — Save lesson for future runs
-  - "Both" — Fix now AND save lesson
+> "Any feedback on the skill creation process? [y/n]"
 
-- **Fix now**: Update skill files, re-validate
-- **Learn**: Run `/to-jaan-learn-add to-jaan-skill-create "{feedback}"`
-- **Both**: Do both
+If yes:
+- Run `/to-jaan-learn-add to-jaan-skill-create "{feedback}"`
 
 ---
 

--- a/skills/to-jaan-skill-create/template.md
+++ b/skills/to-jaan-skill-create/template.md
@@ -62,13 +62,7 @@ If the file exists, apply its lessons throughout this execution:
 
 {preview_description}
 
-Use AskUserQuestion:
-- Question: "Ready to proceed with generation?"
-- Header: "Proceed"
-- Options:
-  - "Yes" — Generate the output
-  - "No" — Cancel
-  - "Edit" — Let me revise the inputs first
+> "Ready to proceed? [y/n]"
 
 **Do NOT proceed to Phase 2 without explicit approval.**
 
@@ -89,12 +83,8 @@ If any check fails, revise before preview.
 
 ## Step 5: Preview & Approval
 
-Show complete output and use AskUserQuestion:
-- Question: "Write to `{output_path}`?"
-- Header: "Write"
-- Options:
-  - "Yes" — Write the file
-  - "No" — Cancel
+Show complete output and ask:
+> "Write to `{output_path}`? [y/n]"
 
 ## Step 6: Write Output
 
@@ -106,18 +96,14 @@ If approved:
 
 ## Step 7: Capture Feedback
 
-Use AskUserQuestion:
-- Question: "Any feedback on the output?"
-- Header: "Feedback"
-- Options:
-  - "No" — All good, done
-  - "Fix now" — Update this output
-  - "Learn" — Save lesson for future runs
-  - "Both" — Fix now AND save lesson
+> "Any feedback? [y/n]"
 
-- **Fix now**: Update output, re-preview, re-write
-- **Learn**: Run `/to-jaan-learn-add {skill_name} "{feedback}"`
-- **Both**: Do both
+If yes:
+> "[1] Fix now  [2] Learn for future  [3] Both"
+
+- **Option 1**: Update output, re-preview, re-write
+- **Option 2**: Run `/to-jaan-learn-add {skill_name} "{feedback}"`
+- **Option 3**: Do both
 
 ---
 

--- a/skills/to-jaan-skill-update/SKILL.md
+++ b/skills/to-jaan-skill-update/SKILL.md
@@ -268,40 +268,6 @@ Check if skill is tech-aware (references project's tech stack):
 - [ ] ✓ Tech-aware (integrates with tech.md)
 - [ ] N/A (skill doesn't need tech context)
 
-### V3.8: AskUserQuestion Usage
-
-Check that structured interactions use AskUserQuestion instead of text prompts:
-
-**Expected patterns** (v3.8 compliant):
-```markdown
-# ✓ Uses AskUserQuestion
-Use AskUserQuestion to ask the user:
-- Question: "Ready to proceed?"
-- Header: "Proceed"
-- Options:
-  - "Yes" — Generate the output
-  - "No" — Cancel
-
-# ✗ Uses text prompt for structured choice
-> "Proceed? [y/n]"
-> "[1] Fix now  [2] Learn  [3] Both"
-```
-
-**Check these sections**:
-1. HARD STOP gate — must use AskUserQuestion
-2. Preview & Approval — must use AskUserQuestion
-3. Feedback section — must use AskUserQuestion with 3-4 options
-4. Any other 2-4 option choices — should use AskUserQuestion
-
-**Detection**: Grep for `> ".*\[y/n` and `> "\[1\]` patterns in SKILL.md.
-
-**Status**:
-- [ ] ✓ HARD STOP uses AskUserQuestion
-- [ ] ✓ Preview uses AskUserQuestion
-- [ ] ✓ Feedback uses AskUserQuestion
-- [ ] ✓ All structured choices (2-4 options) use AskUserQuestion
-- [ ] ✗ Text prompts used for structured choices (suggest option [9])
-
 ### v3.0.0 Compliance Summary
 
 Display results:
@@ -315,14 +281,12 @@ V3.4 Template path:          ✓ / ✗ / N/A
 V3.5 Output path:            ✓ / ✗ / N/A
 V3.6 Template variables:     ✓ / ✗ / N/A
 V3.7 Tech integration:       ✓ / N/A
-V3.8 AskUserQuestion:        ✓ / ✗
 
 VERDICT: v3.0.0 Compliant / Needs Migration
 ```
 
 If **any check fails (✗)**:
 - Add option [8] to Step 3: "Migrate to v3.0.0"
-- If V3.8 fails: Add option [9] to Step 3: "Convert text prompts to AskUserQuestion"
 
 ## Step 3: Ask Update Type
 
@@ -336,41 +300,11 @@ If **any check fails (✗)**:
 > [6] Fix specification compliance issues
 > [7] Other (describe)
 > [8] Migrate to v3.0.0 (if compliance check failed)
-> [9] Convert text prompts to AskUserQuestion (if V3.8 check failed)
-
-**Option 9 (Convert to AskUserQuestion)**:
-
-Scan the target skill for text-based prompts that should use AskUserQuestion:
-
-1. **Find all prompt patterns**: Grep for `> ".*\[y/n` and `> "\[1\]` and `> ".*? \[` patterns
-2. **Categorize each prompt**:
-   - **Convertible** (2-4 fixed options): HARD STOP [y/n/edit], Preview [y/n], Feedback [y/n] + [1-3], confirmations
-   - **Must stay as text** (5+ options, open-ended): menus with 5+ items, free-text input, multi-line
-3. **Show conversion plan**:
-   ```
-   ASKUSERQUESTION CONVERSION PLAN
-   ─────────────────────────────────
-   ✓ Convert (2-4 options):
-     Line {n}: "Proceed? [y/n]" → AskUserQuestion (Yes/No)
-     Line {n}: "[1] Fix [2] Learn [3] Both" → AskUserQuestion (3 options)
-
-   ✗ Keep as text:
-     Line {n}: "[1]...[2]...[8]..." → Too many options
-     Line {n}: "What is the...?" → Open-ended
-
-   Total: {x} convertible, {y} keep as text
-   ```
-4. **Apply conversions**: Replace text prompts with AskUserQuestion instruction blocks
-5. **Validate**: Ensure converted prompts follow the spec pattern from `docs/extending/create-skill.md` "User Interaction Patterns" section
 
 ## Step 4: Optional Web Research
 
-For options [1], [2], [3], or [7], use AskUserQuestion:
-- Question: "Search for updated best practices?"
-- Header: "Research"
-- Options:
-  - "Yes" — Research current best practices
-  - "No" — Skip research
+For options [1], [2], [3], or [7], offer:
+> "Search for updated best practices? [y/n]"
 
 If yes, use **Task tool with Explore subagent**:
 ```
@@ -466,13 +400,7 @@ Show preview of all transformations before applying.
 For each detected v2.x pattern:
 1. Show current code
 2. Show proposed v3.0.0 replacement
-3. Use AskUserQuestion:
-   - Question: "Apply this change?"
-   - Header: "Apply"
-   - Options:
-     - "Yes" — Apply this change
-     - "No" — Skip this change
-     - "Skip all" — Keep remaining as-is
+3. Ask: "Apply this change? [y/n/skip-all]"
 
 #### Option 8.3: Generate Auto-Fix Script
 
@@ -584,13 +512,7 @@ COMPLIANCE AFTER UPDATE
 ✓ Trust: sandboxed
 ```
 
-Use AskUserQuestion to ask the user:
-- Question: "Apply these changes?"
-- Header: "Apply"
-- Options:
-  - "Yes" — Apply all changes
-  - "No" — Cancel and discard
-  - "Edit" — Let me revise the plan first
+> "Apply these changes? [y/n/edit]"
 
 **Do NOT proceed to Phase 2 without explicit approval.**
 
@@ -639,12 +561,7 @@ If any check fails, fix before continuing.
 
 Show final versions of all modified files.
 
-Use AskUserQuestion:
-- Question: "Write these updates?"
-- Header: "Write"
-- Options:
-  - "Yes" — Write all updated files
-  - "No" — Cancel
+> "Write these updates? [y/n]"
 
 ## Step 11: Write Updated Files
 
@@ -693,12 +610,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 > /to-jaan-docs-create skill "my-new-feature"
 > ```
 >
-Use AskUserQuestion:
-- Question: "Did the skill work correctly?"
-- Header: "Test"
-- Options:
-  - "Yes" — Works as expected
-  - "No" — Has issues to fix
+> "Did it work correctly? [y/n]"
 
 If issues:
 1. Help debug the problem
@@ -708,12 +620,8 @@ If issues:
 
 ## Step 15: Create Pull Request
 
-When user confirms working, use AskUserQuestion:
-- Question: "Create pull request to merge to main?"
-- Header: "PR"
-- Options:
-  - "Yes" — Push branch and create PR
-  - "No" — Keep branch, merge manually later
+When user confirms working:
+> "Create pull request to merge to main? [y/n]"
 
 If yes:
 ```bash
@@ -750,18 +658,10 @@ If no:
 
 ## Step 16: Capture Feedback
 
-Use AskUserQuestion:
-- Question: "Any feedback on the skill update process?"
-- Header: "Feedback"
-- Options:
-  - "No" — All good, done
-  - "Fix now" — Update something in the skill
-  - "Learn" — Save lesson for future runs
-  - "Both" — Fix now AND save lesson
+> "Any feedback on the skill update process? [y/n]"
 
-- **Fix now**: Update skill files, re-validate
-- **Learn**: Run `/to-jaan-learn-add to-jaan-skill-update "{feedback}"`
-- **Both**: Do both
+If yes:
+- Run `/to-jaan-learn-add to-jaan-skill-update "{feedback}"`
 
 ### v3.0.0 Migration Feedback (if Option 8 was used)
 


### PR DESCRIPTION
## Summary

- Revert AskUserQuestion → text-based prompts across 16 skills
- Remove AskUserQuestion documentation and tooling
- Bump to v3.8.0

## Motivation

Simplify skill implementation by returning to text-based interaction patterns.

## Changes

**Reverted (13 files):**
- Commit 99ba129 changes using git revert

**Manually converted (3 files):**
- jaan-to-dev-be-task-breakdown
- jaan-to-ux-heatmap-analyze
- jaan-to-dev-stack-detect

**Documentation:**
- Removed "User Interaction Patterns" from create-skill.md
- Updated skill-create template with text prompts
- Removed AskUserQuestion conversion from skill-update

**Text Prompt Examples:**
- Simple: `> "Ready? [y/n]"`
- Multiple: `> "[1] Fix now\n[2] Learn\n[3] Both"`
- Conditional: `> "Confirm? [y/n/edit]"`

## Testing

✅ Verified text prompts in prd-write, learn-add, dev-be-task-breakdown
✅ All 16 skills converted successfully
✅ CHANGELOG entry added for v3.8.0

## Files Changed

16 files changed, 337 insertions(+), 908 deletions(-)

- CHANGELOG.md
- docs/extending/create-skill.md
- skills/jaan-to-data-gtm-datalayer/SKILL.md
- skills/jaan-to-dev-be-task-breakdown/SKILL.md
- skills/jaan-to-dev-stack-detect/SKILL.md
- skills/jaan-to-pm-prd-write/SKILL.md
- skills/jaan-to-pm-research-about/SKILL.md
- skills/jaan-to-pm-story-write/SKILL.md
- skills/jaan-to-ux-heatmap-analyze/SKILL.md
- skills/to-jaan-docs-create/SKILL.md
- skills/to-jaan-docs-update/SKILL.md
- skills/to-jaan-learn-add/SKILL.md
- skills/to-jaan-roadmap-add/SKILL.md
- skills/to-jaan-skill-create/SKILL.md
- skills/to-jaan-skill-create/template.md
- skills/to-jaan-skill-update/SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)