### PR TITLE
fix: Align skill-create, skill-update, and spec with v3.16.2 naming (v3.16.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "jaan-to",
-  "version": "3.16.2",
+  "version": "3.16.3",
   "description": "Give soul to your workflow — AI-powered skills for PM, Data, QA, Dev, and more",
   "owner": {
     "name": "Parhum Khoshbakht",
@@ -12,7 +12,7 @@
     {
       "name": "jaan-to",
       "description": "AI-powered plugin with 19 skills for product management, development, UX research, QA testing, and data analytics. Generate PRDs, user stories, task breakdowns, frontend components, test cases, GTM tracking, and more. Features: two-phase workflow with human approval, quality-reviewer agent, context-scout agent, LEARN.md continuous improvement system.",
-      "version": "3.16.2",
+      "version": "3.16.3",
       "author": {
         "name": "Parhum Khoshbakht",
         "email": "parhum.kh@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jaan-to",
-  "version": "3.16.2",
+  "version": "3.16.3",
   "description": "Give soul to your workflow. 19 AI-powered skills for product management (PRDs, user stories), development (frontend/backend task breakdowns, component design), UX research synthesis, QA test cases (BDD/Gherkin), and data analytics (GTM tracking). Features two-phase workflow with human approval, quality-reviewer agent, and continuous improvement via LEARN.md system.",
   "author": {
     "name": "Parhum Khoshbakht",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the jaan.to Claude Code Plugin will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.3] - 2026-02-07
+
+### Fixed
+- **Spec: removed outdated "Logical Name" concept** — Removed colon-format `{role}:{domain-action}` references from `docs/extending/create-skill.md`; H1 title guidance now uses `# {name}` (kebab-case)
+- **skill-create: fixed command format** — Command preview now shows `/jaan-to:{name}` instead of `/{name}`
+- **skill-create: fixed spec path** — Validation step referenced wrong path `jaan-to/docs/create-skill.md` → `docs/extending/create-skill.md`
+- **skill-create: template uses `{skill_name}`** — Replaced `{logical_name}` variable with `{skill_name}` in template.md
+- **skill-update: fixed stale directory refs** — Updated `skills/jaan-to:pm-prd-write/` → `skills/pm-prd-write/` (2 locations)
+- **skill-update: fixed spec path** — Same `jaan-to/docs/` → `docs/extending/` correction
+- **LEARN.md files** — Fixed stale `jaan-to:pm-prd-write` directory references in both skill LEARN.md files
+
+---
+
 ## [3.16.2] - 2026-02-07
 
 ### Changed

--- a/docs/extending/create-skill.md
+++ b/docs/extending/create-skill.md
@@ -31,7 +31,6 @@ A skill is a reusable command that AI executes to produce outputs. This specific
 | Name | `{name}` |
 | Command | `/{name}` |
 | Directory | `skills/{name}/` (plugin) |
-| Logical Name | `{role}:{domain-action}` |
 | Output | `$JAAN_OUTPUTS_DIR/{role}/{domain}/{slug}/` (project) |
 | Templates | `$JAAN_TEMPLATES_DIR/{name}.template.md` (project) |
 | Learning | `$JAAN_LEARN_DIR/{name}.learn.md` (project) |
@@ -61,12 +60,12 @@ Internal skills (for plugin maintenance):
 
 ### Examples
 
-| Skill Name | Command | Logical Name |
-|------------|---------|--------------|
-| `pm-prd-write` | `/jaan-to:pm-prd-write` | `pm-prd-write` |
-| `qa-plan-test-matrix` | `/jaan-to:qa-plan-test-matrix` | `qa:plan-test-matrix` |
-| `docs-create` | `/jaan-to:docs-create` | `docs:create` |
-| `dev-api-contract` | `/jaan-to:dev-api-contract` | `dev:api-contract` |
+| Skill Name | Command |
+|------------|---------|
+| `pm-prd-write` | `/jaan-to:pm-prd-write` |
+| `qa-plan-test-matrix` | `/jaan-to:qa-plan-test-matrix` |
+| `docs-create` | `/jaan-to:docs-create` |
+| `dev-api-contract` | `/jaan-to:dev-api-contract` |
 
 ---
 
@@ -79,7 +78,7 @@ Every skill needs these files in `skills/{name}/`:
 | `SKILL.md` | Yes | Execution instructions |
 | `template.md` | No | Output format template |
 
-Learning lessons are stored in `jaan-to/learn/{name}.learn.md` (managed by the system).
+Learning lessons are stored in `$JAAN_LEARN_DIR/{name}.learn.md` (managed by the system).
 
 ---
 
@@ -282,7 +281,7 @@ name: {skill-name}
 description: |
   {1-2 sentence purpose}
   Auto-triggers on: {context clues}
-  Maps to: {logical-name}
+  Maps to: {name}
 allowed-tools: {tool-list}
 argument-hint: {expected-format}
 ---
@@ -329,7 +328,7 @@ argument-hint: {expected-format}
 After frontmatter, SKILL.md follows this structure:
 
 ```markdown
-# {role}:{domain-action}
+# {name}
 
 > {One-line purpose}
 
@@ -434,7 +433,7 @@ If yes:
 
 | Section | Level | Purpose |
 |---------|-------|---------|
-| `# {role}:{domain-action}` | H1 | Title with logical name |
+| `# {name}` | H1 | Title matching skill name |
 | `> {tagline}` | blockquote | One-line description |
 | `## Context Files` | H2 | Files to read before execution |
 | `## Input` | H2 | How to interpret $ARGUMENTS |
@@ -1100,7 +1099,7 @@ Accumulated lessons from past executions.
 
 ### Body Checklist
 
-- [ ] Has H1 title with logical name (`role:domain-action`)
+- [ ] Has H1 title matching skill name (`{name}`)
 - [ ] Has tagline blockquote
 - [ ] Has `## Context Files` section
 - [ ] Has `## Input` section
@@ -1169,7 +1168,7 @@ Register new skills in `jaan-to/context/config.md`:
 | Skill | Command | Description |
 |-------|---------|-------------|
 | `pm-prd-write` | `/jaan-to:pm-prd-write` | Generate PRD |
-| `your:new-skill` | `/your-new-skill` | Your description |
+| `your-new-skill` | `/jaan-to:your-new-skill` | Your description |
 ```
 
 ---
@@ -1188,12 +1187,12 @@ name: example-minimal-demo
 description: |
   Demonstrate minimal skill structure.
   Auto-triggers on: demo, example, test skill.
-  Maps to: example:minimal-demo
+  Maps to: example-minimal-demo
 allowed-tools: Read, Write($JAAN_OUTPUTS_DIR/example/**)
 argument-hint: [topic]
 ---
 
-# example:minimal-demo
+# example-minimal-demo
 
 > Demonstrate minimal skill structure.
 
@@ -1288,7 +1287,7 @@ If yes:
 
 Complete skill with all v3.0.0 patterns:
 
-**`skills/jaan-to:qa-test-matrix/SKILL.md`**:
+**`skills/qa-test-matrix/SKILL.md`**:
 
 ```markdown
 ---

--- a/skills/skill-create/LEARN.md
+++ b/skills/skill-create/LEARN.md
@@ -45,7 +45,7 @@ MAIN_FILE="${OUTPUT_FOLDER}/${NEXT_ID}-{report-type}-${slug}.md"
 - Don't skip index management
 - Don't forget Executive Summary section
 
-**Reference**: See `skills/jaan-to:pm-prd-write/SKILL.md` for compliant example.
+**Reference**: See `skills/pm-prd-write/SKILL.md` for compliant example.
 
 ## Common Mistakes
 

--- a/skills/skill-create/SKILL.md
+++ b/skills/skill-create/SKILL.md
@@ -117,8 +117,8 @@ Ask these questions one at a time:
 
 **After answers**, validate and show:
 > "Skill name will be: `{role}-{domain}-{action}`"
-> "Command: `/{role}-{domain}-{action}`"
-> "Logical name: `{role}-{domain}-{action}`"
+> "Command: `/jaan-to:{role}-{domain}-{action}`"
+> "Directory: `skills/{role}-{domain}-{action}/`"
 
 ## Step 1.5: Check Project Configuration (v3.0.0)
 
@@ -350,7 +350,7 @@ Based on output format from Step 4:
 
 ## Step 10: Validate Against Specification
 
-Check against `jaan-to/docs/create-skill.md`:
+Check against `docs/extending/create-skill.md`:
 
 **Frontmatter**:
 - [ ] Has `name` matching directory
@@ -360,7 +360,7 @@ Check against `jaan-to/docs/create-skill.md`:
 - [ ] Does NOT have `model:` field (causes API errors)
 
 **Body**:
-- [ ] Has H1 title with logical name
+- [ ] Has H1 title matching skill name
 - [ ] Has tagline blockquote
 - [ ] Has `## Context Files`
 - [ ] Has `## Input`

--- a/skills/skill-create/template.md
+++ b/skills/skill-create/template.md
@@ -12,12 +12,12 @@ name: {skill_name}
 description: |
   {description_line_1}
   Auto-triggers on: {trigger_phrases}.
-  Maps to: {logical_name}
+  Maps to: {skill_name}
 allowed-tools: {tool_list}
 argument-hint: {argument_format}
 ---
 
-# {logical_name}
+# {skill_name}
 
 > {one_line_purpose}
 
@@ -325,7 +325,7 @@ Generated at: {{env:JAAN_OUTPUTS_DIR}}/{{role}}/{{domain}}/
 | Placeholder | Source |
 |-------------|--------|
 | `{skill_name}` | Step 1: role-domain-action |
-| `{logical_name}` | Step 1: role:domain-action |
+| `{skill_name}` | Step 1: role-domain-action |
 | `{description_line_1}` | Step 3: purpose |
 | `{trigger_phrases}` | Step 3: triggers |
 | `{tool_list}` | Step 5: based on needs |

--- a/skills/skill-update/LEARN.md
+++ b/skills/skill-update/LEARN.md
@@ -40,7 +40,7 @@ Process improvements learned from past runs:
    2. Update output step: folder + index
    3. Update template: Executive Summary
 
-   Reference: skills/jaan-to:pm-prd-write/SKILL.md
+   Reference: skills/pm-prd-write/SKILL.md
 ```
 
 **What NOT to do**:

--- a/skills/skill-update/SKILL.md
+++ b/skills/skill-update/SKILL.md
@@ -96,7 +96,7 @@ Display current structure:
 CURRENT SKILL: {name}
 ────────────────────
 Command: /{name}
-Logical: {logical_name}
+Name: {name}
 Description: {description}
 
 FILES
@@ -108,7 +108,7 @@ FILES
 
 ## Step 2: Validate Against Specification
 
-Check current skill against `jaan-to/docs/create-skill.md`:
+Check current skill against `docs/extending/create-skill.md`:
 
 **Frontmatter**:
 - [ ] Has `name` matching directory
@@ -117,7 +117,7 @@ Check current skill against `jaan-to/docs/create-skill.md`:
 - [ ] Has `argument-hint`
 
 **Body**:
-- [ ] Has H1 title with logical name
+- [ ] Has H1 title matching skill name
 - [ ] Has tagline blockquote
 - [ ] Has `## Context Files`
 - [ ] Has `## Input`
@@ -355,7 +355,7 @@ Missing Executive Summary section
    3. Add index management using scripts/lib/index-updater.sh
    4. Add Executive Summary to template
 
-   Reference: skills/jaan-to:pm-prd-write/SKILL.md (compliant example)
+   Reference: skills/pm-prd-write/SKILL.md (compliant example)
 ```
 
 ### v3.0.0 Compliance Summary
@@ -684,7 +684,7 @@ Required changes:
 □ Add Executive Summary to template (if template.md exists)
 □ Update validation checklist
 
-Reference: skills/jaan-to:pm-prd-write/SKILL.md (compliant example)
+Reference: skills/pm-prd-write/SKILL.md (compliant example)
 ```
 
 ### 10.5.2: HARD STOP - Approve Migration


### PR DESCRIPTION
## Summary

- Remove outdated "Logical Name" colon-format concept from authoritative spec (`docs/extending/create-skill.md`)
- Fix command format in `skill-create` to show `/jaan-to:` prefix
- Fix wrong spec path references (`jaan-to/docs/` → `docs/extending/`)
- Replace `{logical_name}` variable with `{skill_name}` in skill-create template
- Fix stale `skills/jaan-to:pm-prd-write/` directory refs in `skill-update`
- Fix LEARN.md stale directory references in both skills

## Files Changed (9)

| File | Changes |
|------|---------|
| `docs/extending/create-skill.md` | Remove Logical Name, fix colon-format names, fix hardcoded paths |
| `skills/skill-create/SKILL.md` | Fix command format, spec path, validation check |
| `skills/skill-create/template.md` | Replace `{logical_name}` → `{skill_name}` |
| `skills/skill-create/LEARN.md` | Fix stale directory ref |
| `skills/skill-update/SKILL.md` | Fix spec path, directory refs, validation check |
| `skills/skill-update/LEARN.md` | Fix stale directory ref |
| `.claude-plugin/plugin.json` | Version bump 3.16.2 → 3.16.3 |
| `.claude-plugin/marketplace.json` | Version bump 3.16.2 → 3.16.3 |
| `CHANGELOG.md` | Add v3.16.3 entry |

## Test plan

- [x] All changes are documentation/reference-only (no runtime behavior affected)
- [x] No frontmatter fields modified (name, allowed-tools, argument-hint unchanged)
- [x] No phase structure altered (PHASE 1, HARD STOP, PHASE 2 intact)
- [x] Grep verification: zero stale colon-format or wrong-path references remain in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)