### PR TITLE
release: v3.17.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "jaan-to",
-  "version": "3.16.3-dev",
+  "version": "3.17.0",
   "description": "Give soul to your workflow — AI-powered skills for PM, Data, QA, Dev, and more",
   "owner": {
     "name": "Parhum Khoshbakht",
@@ -12,7 +12,7 @@
     {
       "name": "jaan-to",
       "description": "AI-powered plugin with 19 skills for product management, development, UX research, QA testing, and data analytics. Generate PRDs, user stories, task breakdowns, frontend components, test cases, GTM tracking, and more. Features: two-phase workflow with human approval, quality-reviewer agent, context-scout agent, LEARN.md continuous improvement system.",
-      "version": "3.16.3-dev",
+      "version": "3.17.0",
       "author": {
         "name": "Parhum Khoshbakht",
         "email": "parhum.kh@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jaan-to",
-  "version": "3.16.3-dev",
+  "version": "3.17.0",
   "description": "Give soul to your workflow. 19 AI-powered skills for product management (PRDs, user stories), development (frontend/backend task breakdowns, component design), UX research synthesis, QA test cases (BDD/Gherkin), and data analytics (GTM tracking). Features two-phase workflow with human approval, quality-reviewer agent, and continuous improvement via LEARN.md system.",
   "author": {
     "name": "Parhum Khoshbakht",

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -68,6 +68,10 @@ jobs:
           echo ""
           echo "✓ No component paths declared (auto-discovery will work)"
 
+      - name: Check skill description character budget
+        run: |
+          bash scripts/validate-skills.sh
+
       - name: Summary
         run: |
           VERSION=$(jq -r '.version' .claude-plugin/plugin.json)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the jaan.to Claude Code Plugin will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.17.0] - 2026-02-07
+
+### Fixed
+- **All 19 skills now discoverable** — Trimmed skill descriptions to fit Claude Code's 15,000 char system prompt budget; removed `Auto-triggers on:` and `Maps to:` lines from all SKILL.md description fields
+
+### Added
+- **CI: Skill budget validation** — New `scripts/validate-skills.sh` checks total description chars; added to `.github/workflows/release-check.yml` to block over-budget PRs
+- **Spec: Description budget rules** — Updated `docs/extending/create-skill.md` with 120-char limit and budget documentation
+- **Style: Skill description rules** — Added description length limits to `docs/STYLE.md`
+- **skill-update: V3.9 compliance check** — Detects bloated descriptions during skill updates
+- **skill-create: Lean descriptions** — Template no longer generates `Auto-triggers on:` / `Maps to:` lines
+
+### Changed
+- **Description format** — Descriptions are now 1-2 sentences (single-line YAML) instead of multi-line with metadata
+
+---
+
 ## [3.16.3] - 2026-02-07
 
 ### Fixed

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -261,6 +261,20 @@ Example output.
 
 ---
 
+## Skill Description Rules
+
+| Rule | Limit |
+|------|-------|
+| Description length | Max 120 chars |
+| Format | 1-2 sentences, no metadata lines |
+| Forbidden | `Auto-triggers on:`, `Maps to:` in description |
+| Budget | All skills combined must fit 15,000 char system prompt budget |
+| Validation | Run `scripts/validate-skills.sh` before release |
+
+Claude Code allocates a fixed character budget for all skill descriptions. Each skill costs ~109 chars overhead + description length. If total exceeds budget, skills get silently dropped from the system prompt.
+
+---
+
 ## Links
 
 ### Internal

--- a/docs/extending/create-skill.md
+++ b/docs/extending/create-skill.md
@@ -278,10 +278,7 @@ Every SKILL.md must begin with YAML frontmatter:
 ```yaml
 ---
 name: {skill-name}
-description: |
-  {1-2 sentence purpose}
-  Auto-triggers on: {context clues}
-  Maps to: {name}
+description: {1-2 sentence purpose. Keep under 120 chars.}
 allowed-tools: {tool-list}
 argument-hint: {expected-format}
 ---
@@ -290,9 +287,21 @@ argument-hint: {expected-format}
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | Yes | Matches directory name |
-| `description` | multiline | Yes | Purpose + triggers + mapping |
+| `description` | string | Yes | 1-2 sentence purpose (max 120 chars) |
 | `allowed-tools` | string | Yes | Comma-separated tool permissions |
 | `argument-hint` | string | Yes | Shows expected input format |
+
+### Description Budget
+
+Claude Code allocates a **15,000 character budget** for all skill descriptions in the system prompt. Each skill costs ~109 chars of XML overhead plus the description length. If total exceeds budget, skills get silently dropped.
+
+**Rules:**
+- Keep descriptions under **120 chars** (1-2 sentences)
+- Do NOT include `Auto-triggers on:` or `Maps to:` lines
+- Use single-line YAML format (no `|` block scalar needed)
+- Run `scripts/validate-skills.sh` to check budget before release
+
+**Override:** Set `SLASH_COMMAND_TOOL_CHAR_BUDGET` environment variable to adjust the budget.
 
 ### Tool Permission Patterns (v3.0.0)
 
@@ -1093,7 +1102,7 @@ Accumulated lessons from past executions.
 ### Frontmatter Checklist
 
 - [ ] Has `name` matching directory
-- [ ] Has `description` with purpose and mapping
+- [ ] Has `description` with purpose (max 120 chars, no `Auto-triggers on:`/`Maps to:` lines)
 - [ ] Has `allowed-tools` with valid tool patterns
 - [ ] Has `argument-hint` showing expected format
 
@@ -1184,10 +1193,7 @@ Simplest valid skill structure:
 ```markdown
 ---
 name: example-minimal-demo
-description: |
-  Demonstrate minimal skill structure.
-  Auto-triggers on: demo, example, test skill.
-  Maps to: example-minimal-demo
+description: Demonstrate minimal skill structure.
 allowed-tools: Read, Write($JAAN_OUTPUTS_DIR/example/**)
 argument-hint: [topic]
 ---
@@ -1292,10 +1298,7 @@ Complete skill with all v3.0.0 patterns:
 ```markdown
 ---
 name: qa-test-matrix
-description: |
-  Generate comprehensive test matrix from feature requirements.
-  Auto-triggers on: test planning, QA coverage, test matrix requests.
-  Maps to: qa-test-matrix
+description: Generate comprehensive test matrix from feature requirements.
 allowed-tools: Read, Glob, Grep, Task, WebSearch, Write($JAAN_OUTPUTS_DIR/qa/**)
 argument-hint: [feature-name-or-prd-path]
 ---

--- a/examples/starter-project/jaan-to/docs/create-skill.md
+++ b/examples/starter-project/jaan-to/docs/create-skill.md
@@ -279,10 +279,7 @@ Every SKILL.md must begin with YAML frontmatter:
 ```yaml
 ---
 name: {skill-name}
-description: |
-  {1-2 sentence purpose}
-  Auto-triggers on: {context clues}
-  Maps to: {logical-name}
+description: {1-2 sentence purpose. Keep under 120 chars.}
 allowed-tools: {tool-list}
 argument-hint: {expected-format}
 ---
@@ -291,7 +288,7 @@ argument-hint: {expected-format}
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | Yes | Matches directory name |
-| `description` | multiline | Yes | Purpose + triggers + mapping |
+| `description` | string | Yes | 1-2 sentence purpose (max 120 chars) |
 | `allowed-tools` | string | Yes | Comma-separated tool permissions |
 | `argument-hint` | string | Yes | Shows expected input format |
 
@@ -1185,10 +1182,7 @@ Simplest valid skill structure:
 ```markdown
 ---
 name: example-minimal-demo
-description: |
-  Demonstrate minimal skill structure.
-  Auto-triggers on: demo, example, test skill.
-  Maps to: example:minimal-demo
+description: Demonstrate minimal skill structure.
 allowed-tools: Read, Write($JAAN_OUTPUTS_DIR/example/**)
 argument-hint: [topic]
 ---
@@ -1293,10 +1287,7 @@ Complete skill with all v3.0.0 patterns:
 ```markdown
 ---
 name: jaan-to-qa-test-matrix
-description: |
-  Generate comprehensive test matrix from feature requirements.
-  Auto-triggers on: test planning, QA coverage, test matrix requests.
-  Maps to: qa:test-matrix
+description: Generate comprehensive test matrix from feature requirements.
 allowed-tools: Read, Glob, Grep, Task, WebSearch, Write($JAAN_OUTPUTS_DIR/qa/**)
 argument-hint: [feature-name-or-prd-path]
 ---

--- a/examples/starter-project/jaan-to/templates/to-jaan-skill-create.template.md
+++ b/examples/starter-project/jaan-to/templates/to-jaan-skill-create.template.md
@@ -9,10 +9,7 @@
 ```markdown
 ---
 name: {skill_name}
-description: |
-  {description_line_1}
-  Auto-triggers on: {trigger_phrases}.
-  Maps to: {logical_name}
+description: {description_line_1}
 allowed-tools: {tool_list}
 argument-hint: {argument_format}
 ---

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# validate-skills.sh — Check total skill description character budget
+#
+# Claude Code allocates a fixed budget (default 15,000 chars) for all skill
+# descriptions in the system prompt. Each skill costs ~109 chars of XML
+# overhead plus the description length. If total exceeds budget, skills
+# get silently dropped.
+#
+# Usage: bash scripts/validate-skills.sh [budget]
+# Exit 0 if under budget, exit 1 if over.
+
+set -euo pipefail
+
+BUDGET="${1:-${SLASH_COMMAND_TOOL_CHAR_BUDGET:-15000}}"
+OVERHEAD_PER_SKILL=109  # approximate XML wrapper chars per skill
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+SKILLS_DIR="$PLUGIN_ROOT/skills"
+
+TOTAL=0
+COUNT=0
+DETAILS=""
+
+for skill_dir in "$SKILLS_DIR"/*/; do
+  skill_file="$skill_dir/SKILL.md"
+  [ -f "$skill_file" ] || continue
+
+  skill_name="$(basename "$skill_dir")"
+
+  # Extract description from YAML frontmatter
+  # Handles both single-line and multi-line (block scalar) descriptions
+  desc=""
+  in_frontmatter=false
+  in_desc=false
+  while IFS= read -r line; do
+    if [[ "$line" == "---" ]]; then
+      if $in_frontmatter; then
+        break  # end of frontmatter
+      fi
+      in_frontmatter=true
+      continue
+    fi
+
+    if $in_frontmatter; then
+      if [[ "$line" =~ ^description:\ *\|[[:space:]]*$ ]]; then
+        # Multi-line block scalar
+        in_desc=true
+        continue
+      elif [[ "$line" =~ ^description:\ *\"(.*)\"$ ]]; then
+        # Quoted single-line: description: "text"
+        desc="${BASH_REMATCH[1]}"
+        break
+      elif [[ "$line" =~ ^description:\ *(.+)$ ]]; then
+        # Unquoted single-line: description: text
+        desc="${BASH_REMATCH[1]}"
+        break
+      fi
+
+      if $in_desc; then
+        # Multi-line continuation: indented lines
+        if [[ "$line" =~ ^[[:space:]]+ ]]; then
+          desc+="${line#"${line%%[![:space:]]*}"}"$'\n'
+        else
+          break
+        fi
+      fi
+    fi
+  done < "$skill_file"
+
+  desc_len=${#desc}
+  skill_cost=$((desc_len + OVERHEAD_PER_SKILL))
+  TOTAL=$((TOTAL + skill_cost))
+  COUNT=$((COUNT + 1))
+
+  DETAILS+="$(printf "  %-35s %4d chars  (desc: %d + overhead: %d)\n" "$skill_name" "$skill_cost" "$desc_len" "$OVERHEAD_PER_SKILL")"$'\n'
+done
+
+echo "═══════════════════════════════════════"
+echo "  Skill Description Budget Check"
+echo "═══════════════════════════════════════"
+echo ""
+echo "Skills found: $COUNT"
+echo ""
+echo "$DETAILS"
+echo "───────────────────────────────────────"
+printf "  %-35s %4d chars\n" "TOTAL" "$TOTAL"
+printf "  %-35s %4d chars\n" "BUDGET" "$BUDGET"
+printf "  %-35s %4d chars\n" "REMAINING" "$((BUDGET - TOTAL))"
+echo ""
+
+if [ "$TOTAL" -gt "$BUDGET" ]; then
+  OVER=$((TOTAL - BUDGET))
+  echo "::error::Skill descriptions exceed budget by $OVER chars ($TOTAL / $BUDGET)"
+  echo ""
+  echo "Fix: Shorten descriptions in skills/*/SKILL.md"
+  echo "     Keep each description under 120 chars (1-2 sentences)"
+  echo "     Override budget: SLASH_COMMAND_TOOL_CHAR_BUDGET=20000 bash $0"
+  exit 1
+fi
+
+echo "✓ Under budget ($TOTAL / $BUDGET)"

--- a/skills/data-gtm-datalayer/SKILL.md
+++ b/skills/data-gtm-datalayer/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: data-gtm-datalayer
-description: |
-  Generate production-ready GTM tracking code (dataLayer pushes and HTML attributes).
-  Auto-triggers on: gtm tracking, datalayer push, tracking code, impression tracking, click tracking gtm, al_tracker.
-  Maps to: data-gtm-datalayer
+description: Generate production-ready GTM tracking code (dataLayer pushes and HTML attributes).
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**)
 argument-hint: [prd-path | tracking-description | (interactive)]
 ---

--- a/skills/dev-be-task-breakdown/SKILL.md
+++ b/skills/dev-be-task-breakdown/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: dev-be-task-breakdown
-description: |
-  Convert a PRD into structured backend development tasks with data model notes,
-  idempotency patterns, reliability considerations, and error taxonomy.
-  Auto-triggers on: backend tasks, task breakdown, be tasks, dev task list, break down PRD
-  Maps to: dev-be-task-breakdown
+description: Convert a PRD into structured backend development tasks with data model notes, reliability patterns, and error taxonomy.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task
 argument-hint: [prd-path] OR [feature-description]
 ---

--- a/skills/dev-fe-design/SKILL.md
+++ b/skills/dev-fe-design/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: dev-fe-design
-description: |
-  Create distinctive, production-grade frontend interfaces with bold design choices.
-  Generates actual working code (HTML/CSS/JS, React, Vue, etc.) avoiding generic AI aesthetics.
-  Auto-triggers on: frontend design, create component, design component, build ui, create interface
-  Maps to: dev-fe-design
+description: Create distinctive, production-grade frontend interfaces with bold design choices and working code.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task, WebSearch, AskUserQuestion
 argument-hint: [component-description-or-requirements]
 ---

--- a/skills/dev-fe-task-breakdown/SKILL.md
+++ b/skills/dev-fe-task-breakdown/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: dev-fe-task-breakdown
-description: |
-  Generate frontend task breakdowns from UX handoffs.
-  Produces component inventory, state matrices, estimate bands, dependencies, and risks.
-  Auto-triggers on: frontend tasks, fe breakdown, component breakdown, ux handoff tasks
-  Maps to: dev-fe-task-breakdown
+description: Generate frontend task breakdowns from UX handoffs with component inventory, state matrices, and estimates.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task, WebSearch, AskUserQuestion
 argument-hint: [ux-handoff-description-or-figma-link]
 ---

--- a/skills/dev-stack-detect/SKILL.md
+++ b/skills/dev-stack-detect/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: dev-stack-detect
-description: |
-  Auto-detect project tech stack and populate jaan.to context files.
-  Scans languages, frameworks, databases, infrastructure, CI/CD, and integrations.
-  Auto-triggers on: detect stack, scan project, setup context, analyze tech
-  Maps to: dev-stack-detect
+description: Auto-detect project tech stack and populate jaan.to context files.
 allowed-tools: Read, Glob, Grep, Bash(git remote:*), Bash(ls:*), Write($JAAN_CONTEXT_DIR/**), Edit($JAAN_CONTEXT_DIR/**), Write($JAAN_OUTPUTS_DIR/dev/**)
 argument-hint: [optional-focus-area]
 ---

--- a/skills/docs-create/SKILL.md
+++ b/skills/docs-create/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: docs-create
-description: |
-  Create new documentation with templates following STYLE.md.
-  Supports: skill, hook, config, guide, concept, index.
-  Maps to: docs-create
+description: Create new documentation with templates following STYLE.md.
 allowed-tools: Read, Glob, Grep, Write(docs/**), Write($JAAN_OUTPUTS_DIR/**), Bash(git add:*), Bash(git commit:*)
 argument-hint: "{type} {name}"
 ---

--- a/skills/docs-update/SKILL.md
+++ b/skills/docs-update/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: docs-update
-description: |
-  Audit and maintain documentation quality.
-  Default: Smart staleness check using git history.
-  Maps to: docs-update
+description: Audit and maintain documentation quality using smart staleness checks.
 allowed-tools: Read, Glob, Grep, Write(docs/**), Write($JAAN_OUTPUTS_DIR/**), Edit, Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git mv:*)
 argument-hint: "[path] [--full] [--fix] [--check-only] [--quick]"
 ---

--- a/skills/learn-add/SKILL.md
+++ b/skills/learn-add/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: learn-add
-description: |
-  Add a lesson to a skill's LEARN.md file.
-  Routes feedback to skill, template, or context learning.
-  Maps to: learn-add
+description: Add a lesson to a skill's LEARN.md file, routing feedback to skill, template, or context learning.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**), Bash(git add:*), Bash(git commit:*)
 argument-hint: "[target] [lesson]"
 ---

--- a/skills/pm-prd-write/SKILL.md
+++ b/skills/pm-prd-write/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: pm-prd-write
-description: |
-  Generate a Product Requirements Document from an initiative description.
-  Auto-triggers on: feature requirements, PRD requests, product specifications.
-  Maps to: pm-prd-write
+description: Generate a Product Requirements Document from an initiative description.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**)
 argument-hint: [initiative-description]
 hooks:

--- a/skills/pm-research-about/SKILL.md
+++ b/skills/pm-research-about/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: pm-research-about
-description: |
-  Deep research on any topic, or add existing file/URL to research index.
-  Auto-triggers on: research about, deep dive, investigate, research on, add research, index research
-  Maps to: pm-research-about
+description: Deep research on any topic, or add existing file/URL to research index.
 allowed-tools: Task, WebSearch, WebFetch, Read, Glob, Grep, Write(jaan-to/outputs/research/**), Edit, Bash(git add:*), Bash(git commit:*)
 argument-hint: <topic-or-file-path-or-URL>
 ---

--- a/skills/pm-story-write/SKILL.md
+++ b/skills/pm-story-write/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: pm-story-write
-description: |
-  Generate user stories with Given/When/Then acceptance criteria following INVEST principles.
-  Auto-triggers on: write user story, create story, user story for, story write, generate story
-  Maps to: pm-story-write
+description: Generate user stories with Given/When/Then acceptance criteria following INVEST principles.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**), Task
 argument-hint: [feature] [persona] [goal] OR [epic-id]
 ---

--- a/skills/qa-test-cases/SKILL.md
+++ b/skills/qa-test-cases/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: qa-test-cases
-description: |
-  Generate production-ready BDD/Gherkin test cases from acceptance criteria.
-  Applies ISTQB test design techniques (equivalence partitioning, BVA).
-  Auto-triggers on: test cases, acceptance criteria, QA, BDD, Gherkin
-  Maps to: qa-test-cases
+description: Generate production-ready BDD/Gherkin test cases from acceptance criteria using ISTQB techniques.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/qa/**), Task, WebSearch
 argument-hint: [acceptance-criteria | prd-path | jira-id | (interactive)]
 ---

--- a/skills/roadmap-add/SKILL.md
+++ b/skills/roadmap-add/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: roadmap-add
-description: |
-  [Internal] Add a task to the jaan.to development roadmap.
-  For jaan.to project maintenance, not end-user use.
-  Maps to: roadmap-add
+description: "[Internal] Add a task to the jaan.to development roadmap."
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**)
 argument-hint: [task-description]
 ---

--- a/skills/roadmap-update/SKILL.md
+++ b/skills/roadmap-update/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: roadmap-update
-description: |
-  [Internal] Maintain and sync the jaan.to development roadmap.
-  Syncs git history, marks tasks done, creates version sections, validates links.
-  Auto-triggers on: update roadmap, sync roadmap, release version, roadmap maintenance.
-  Maps to: roadmap-update
+description: "[Internal] Maintain and sync the jaan.to development roadmap."
 allowed-tools: Read, Glob, Grep, Edit, Bash(git log:*), Bash(git tag:*), Bash(git diff:*), Bash(git status:*), Bash(git add:*), Bash(git commit:*), Bash(git describe:*), Bash(git branch:*), Bash(git push:*), Bash(git checkout:*), Bash(git merge:*), Write(roadmaps/**)
 argument-hint: "[mark \"<task>\" done <hash>] [release vX.Y.Z \"<summary>\"] [bump-dev] [sync] [validate] [(no args)]"
 ---

--- a/skills/skill-create/SKILL.md
+++ b/skills/skill-create/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: skill-create
-description: |
-  Guide users through creating new jaan.to skills step-by-step.
-  Auto-triggers on: create skill, new skill, skill wizard, add skill.
-  Maps to: skill-create
+description: Guide users through creating new jaan.to skills step-by-step.
 allowed-tools: Read, Glob, Grep, Task, WebSearch, Write(skills/**), Write(docs/**), Write($JAAN_OUTPUTS_DIR/**), Edit($JAAN_TEMPLATES_DIR/**), Edit($JAAN_LEARN_DIR/**), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(gh pr create:*)
 argument-hint: [optional-skill-idea]
 ---

--- a/skills/skill-create/template.md
+++ b/skills/skill-create/template.md
@@ -9,10 +9,7 @@
 ```markdown
 ---
 name: {skill_name}
-description: |
-  {description_line_1}
-  Auto-triggers on: {trigger_phrases}.
-  Maps to: {skill_name}
+description: {description_line_1}
 allowed-tools: {tool_list}
 argument-hint: {argument_format}
 ---
@@ -326,8 +323,7 @@ Generated at: {{env:JAAN_OUTPUTS_DIR}}/{{role}}/{{domain}}/
 |-------------|--------|
 | `{skill_name}` | Step 1: role-domain-action |
 | `{skill_name}` | Step 1: role-domain-action |
-| `{description_line_1}` | Step 3: purpose |
-| `{trigger_phrases}` | Step 3: triggers |
+| `{description_line_1}` | Step 3: purpose (max 120 chars) |
 | `{tool_list}` | Step 5: based on needs |
 | `{argument_format}` | Step 4: input format |
 | `{one_line_purpose}` | Step 3: short version |

--- a/skills/skill-update/SKILL.md
+++ b/skills/skill-update/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: skill-update
-description: |
-  Update an existing jaan.to skill following standards.
-  Auto-triggers on: update skill, modify skill, improve skill, fix skill.
-  Maps to: skill-update
+description: Update an existing jaan.to skill following standards.
 allowed-tools: Read, Glob, Grep, Task, WebSearch, Write(skills/**), Write(docs/**), Write($JAAN_OUTPUTS_DIR/**), Edit, Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(gh pr create:*)
 argument-hint: [skill-name]
 ---
@@ -358,6 +355,22 @@ Missing Executive Summary section
    Reference: skills/pm-prd-write/SKILL.md (compliant example)
 ```
 
+### V3.9: Description Budget Compliance
+
+Check that description field is concise and budget-friendly:
+
+**Rules:**
+- Description should be 1-2 sentences (under 120 chars)
+- Must NOT contain `Auto-triggers on:` line
+- Must NOT contain `Maps to:` line
+- Must use single-line YAML format (no `|` block scalar)
+
+**Detection**: Check description field length and content in YAML frontmatter.
+
+**Status**:
+- [ ] ✓ Description is concise (under 120 chars, no trigger/mapping lines)
+- [ ] ✗ Description too long or contains `Auto-triggers on:` / `Maps to:` lines
+
 ### v3.0.0 Compliance Summary
 
 Display results:
@@ -379,7 +392,11 @@ V3.8.2 Folder structure:        ✓ / ✗ / N/A
 V3.8.3 Index management:        ✓ / ✗ / N/A
 V3.8.4 Executive Summary:       ✓ / ✗ / N/A
 
-VERDICT: v3.0.0 Compliant / Needs Migration / Needs Output Migration
+DESCRIPTION BUDGET
+──────────────────
+V3.9 Description budget:        ✓ / ✗
+
+VERDICT: v3.0.0 Compliant / Needs Migration / Needs Output Migration / Needs Description Fix
 ```
 
 If **any check fails (✗)**:
@@ -399,6 +416,7 @@ If **any check fails (✗)**:
 > [7] Other (describe)
 > [8] Migrate to v3.0.0 (if v3.0.0 compliance check failed)
 > [9] Migrate output structure to ID-based folders (if V3.8 check failed)
+> [10] Fix description budget (trim Auto-triggers/Maps-to lines, shorten description)
 
 ## Step 4: Optional Web Research
 

--- a/skills/ux-heatmap-analyze/SKILL.md
+++ b/skills/ux-heatmap-analyze/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: ux-heatmap-analyze
-description: |
-  Analyze heatmap data from CSV exports and screenshots to generate prioritized UX research reports.
-  Auto-triggers on: heatmap analysis, click analysis, ux heatmap, clarity export, interaction patterns, click patterns, scroll analysis, tap analysis.
-  Maps to: ux-heatmap-analyze
+description: Analyze heatmap data from CSV exports and screenshots to generate prioritized UX research reports.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/**)
 argument-hint: [csv-path] [screenshot-path] [html-path?] [problem?]
 ---

--- a/skills/ux-microcopy-write/SKILL.md
+++ b/skills/ux-microcopy-write/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: ux-microcopy-write
-description: |
-  Generate multi-language microcopy packs for UI components.
-  Supports 7 languages with cultural adaptation, tone-of-voice consistency, and RTL/LTR handling.
-  Auto-triggers on: microcopy, ui copy, button labels, error messages, multi-language content
-  Maps to: ux-microcopy-write
+description: Generate multi-language microcopy packs for UI components with cultural adaptation and RTL/LTR handling.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/**), Write($JAAN_CONTEXT_DIR/localization.md), Write($JAAN_CONTEXT_DIR/tone-of-voice.md), WebSearch, Task, AskUserQuestion, Bash
 argument-hint: [initiative-or-feature-description]
 ---

--- a/skills/ux-research-synthesize/SKILL.md
+++ b/skills/ux-research-synthesize/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: ux-research-synthesize
-description: |
-  Synthesize UX research findings into themed insights, executive summaries, and prioritized recommendations.
-  Supports three synthesis modes: Speed (1-2h), Standard (1-2d), Cross-Study (meta-analysis).
-  Auto-triggers on: research synthesis, thematic analysis, synthesize findings, analyze research, UX synthesis
-  Maps to: ux-research-synthesize
+description: Synthesize UX research findings into themed insights, executive summaries, and prioritized recommendations.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/research/**), Task, AskUserQuestion
 argument-hint: [study-name] [data-sources?]
 ---


### PR DESCRIPTION
## Summary

- **Fixed**: All 19 skills now discoverable — trimmed skill descriptions to fit Claude Code's 15,000 char system prompt budget
- **Added**: CI validation script (`scripts/validate-skills.sh`) to prevent recurrence
- **Updated**: Spec, style guide, skill-create template, and skill-update with V3.9 compliance check

## Root Cause

Claude Code allocates 15,000 chars for all skill descriptions. With 19 skills each including `Auto-triggers on:` and `Maps to:` metadata lines, total exceeded budget and 4 skills were silently dropped (`pm-story-write`, `dev-be-task-breakdown`, `ux-heatmap-analyze`, `ux-research-synthesize`).

## Changes (29 files)

| Area | Files | Change |
|------|-------|--------|
| Skills | `skills/*/SKILL.md` (×19) | Trimmed descriptions to 1-2 sentences |
| CI | `scripts/validate-skills.sh` (NEW) | Budget validation script |
| CI | `.github/workflows/release-check.yml` | Added budget check step |
| Spec | `docs/extending/create-skill.md` | Removed trigger/mapping pattern, added budget rules |
| Template | `skills/skill-create/template.md` | Lean description template |
| Validator | `skills/skill-update/SKILL.md` | Added V3.9 description budget check |
| Style | `docs/STYLE.md` | Added skill description rules |
| Examples | `examples/starter-project/...` (×2) | Updated example files |
| Version | `plugin.json`, `marketplace.json` | 3.16.3 → 3.17.0 |
| Changelog | `CHANGELOG.md` | v3.17.0 entry |

## Budget After Fix

```
Total:     3,645 chars
Budget:   15,000 chars
Remaining: 11,355 chars
```

## Test plan

- [ ] Run `bash scripts/validate-skills.sh` — passes (under budget)
- [ ] Restart Claude Code session
- [ ] Type `/jaan-to:` — all 19 skills appear
- [ ] Test `/jaan-to:pm-story-write` — invocable
- [ ] CI release-check passes with new budget step

🤖 Generated with [Claude Code](https://claude.com/claude-code)