### PR TITLE
chore: unify versioning — remove -dev suffix

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -10,17 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check version format (no -dev suffix)
-        run: |
-          VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
-          if [[ "$VERSION" == *-dev* ]]; then
-            echo "::error::Version contains -dev suffix: $VERSION"
-            echo "Release versions must not contain -dev suffix."
-            echo "Run: ./scripts/bump-version.sh X.Y.Z (without -dev)"
-            exit 1
-          fi
-          echo "✓ Version format valid: $VERSION"
-
       - name: Check all 3 version fields match
         run: |
           V1=$(jq -r '.version' .claude-plugin/plugin.json)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,13 +122,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Two-Branch Development Workflow** — `main` for stable releases, `dev` for development/preview (`ba9c061`)
   - Users can install stable: `/plugin marketplace add parhumm/jaan-to`
   - Users can install dev: `/plugin marketplace add parhumm/jaan-to#dev`
-  - Stable versions: `X.Y.Z` (e.g., `3.15.0`)
-  - Dev versions: `X.Y.Z-dev` (e.g., `3.15.0-dev`)
+  - Both branches use `X.Y.Z` format (e.g., `3.15.0`)
 - **Version Management Scripts**
   - `scripts/bump-version.sh` — Update version in all 3 required locations atomically (plugin.json, marketplace.json top-level, marketplace.json plugins[0])
   - `scripts/setup-branch-protection.sh` — Configure GitHub branch protection (main: require PR + approval, dev: direct pushes allowed)
 - **CI Release Validation** — `.github/workflows/release-check.yml` for PRs to main
-  - Validates no `-dev` suffix in version
   - Ensures all 3 version fields match
   - Checks CHANGELOG entry exists
   - Validates plugin.json has required component paths (skills, agents, hooks)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ jaan.to uses a two-branch development model:
 | Branch | Purpose | Version Format | Install Command |
 |--------|---------|----------------|-----------------|
 | `main` | Stable releases | `3.15.0` | `/plugin marketplace add parhumm/jaan-to` |
-| `dev` | Development/preview | `3.15.0-dev` | `/plugin marketplace add parhumm/jaan-to#dev` |
+| `dev` | Development/preview | `3.15.0` | `/plugin marketplace add parhumm/jaan-to#dev` |
 
 ### Workflow
 
@@ -39,13 +39,13 @@ feature/* ───> dev ───> main
                 │    (release tag)
                 │         │
                 └─────────┘
-              auto-bump dev
+               sync dev
 ```
 
 1. **Daily development**: Work on `dev` branch (direct pushes allowed)
 2. **Feature work**: Create feature branches from `dev`, merge back to `dev`
 3. **Releases**: Create PR from `dev` → `main` (requires review + CI checks)
-4. **After release**: Bump `dev` to next version (e.g., `3.15.0` → `3.16.0-dev`)
+4. **After release**: Sync `dev` from `main`, then bump to next version (e.g., `3.15.0` → `3.16.0`)
 
 ### Contributing to dev
 
@@ -449,34 +449,19 @@ jaan.to follows [Semantic Versioning](https://semver.org/):
 - **Minor (v1.1.0):** New features (backward compatible)
 - **Patch (v1.0.1):** Bug fixes
 
-**Branch versions:**
-- `main`: `X.Y.Z` (e.g., `3.15.0`)
-- `dev`: `X.Y.Z-dev` (e.g., `3.15.0-dev`)
+Both `dev` and `main` use the same `X.Y.Z` format (e.g., `3.15.0`). No `-dev` suffix.
 
 ### Release Checklist (Maintainers Only)
 
-1. **Prepare release branch from dev:**
-   ```bash
-   git checkout dev
-   git checkout -b release/3.15.0
-   ```
+1. **Ensure version and CHANGELOG are ready on `dev`:**
+   - Version should already be bumped in all 3 places via `./scripts/bump-version.sh X.Y.Z`
+   - CHANGELOG.md should have an entry for the version
 
-2. **Update version in 3 places** (remove `-dev` suffix):
-   ```bash
-   ./scripts/bump-version.sh 3.15.0
-   ```
-   This updates:
-   - `.claude-plugin/plugin.json` → `"version": "3.15.0"`
-   - `.claude-plugin/marketplace.json` → `"version": "3.15.0"` (top-level)
-   - `.claude-plugin/marketplace.json` → `"plugins[0].version": "3.15.0"`
-
-3. **Add entry to [CHANGELOG.md](CHANGELOG.md)** following [Keep a Changelog](https://keepachangelog.com/)
-
-4. **Create PR: `release/3.15.0` → `main`**
-   - CI checks: no `-dev` suffix, all 3 versions match, CHANGELOG entry exists
+2. **Create PR: `dev` → `main`**
+   - CI checks: all 3 versions match, CHANGELOG entry exists
    - Requires review and approval
 
-5. **After merge, tag and push:**
+3. **After merge, tag and push:**
    ```bash
    git checkout main
    git pull origin main
@@ -484,16 +469,21 @@ jaan.to follows [Semantic Versioning](https://semver.org/):
    git push origin main --tags
    ```
 
-6. **Bump dev to next version:**
+4. **Sync dev back from main:**
    ```bash
    git checkout dev
    git merge main
-   ./scripts/bump-version.sh 3.16.0-dev
-   git commit -m "chore: bump dev to 3.16.0-dev"
    git push origin dev
    ```
 
-7. **Verify installation works:**
+5. **Bump dev to next version (for next release cycle):**
+   ```bash
+   ./scripts/bump-version.sh 3.16.0
+   git commit -m "chore: bump version to 3.16.0"
+   git push origin dev
+   ```
+
+6. **Verify installation works:**
    ```
    /plugin uninstall jaan-to
    /plugin marketplace add parhumm/jaan-to

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ To switch from dev to stable (or vice versa):
 ```
 /plugin list
 ```
-- Stable versions: `3.15.0`, `3.16.0`, etc.
-- Dev versions: `3.15.0-dev`, `3.16.0-dev`, etc. (includes `-dev` suffix)
+- All versions use the same format: `3.15.0`, `3.16.0`, etc.
 
 ### Local Development
 ```bash

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -10,7 +10,6 @@ VERSION="$1"
 if [ -z "$VERSION" ]; then
   echo "Usage: $0 <version>"
   echo "Example: $0 3.15.0"
-  echo "Example: $0 3.16.0-dev"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Removes the `-dev` version suffix convention — both `dev` and `main` branches now use identical `X.Y.Z` format
- Removes `bump-dev` mode from `roadmap-update` skill
- Removes `-dev` suffix CI validation step from `release-check.yml`
- Updates all documentation (CONTRIBUTING.md, README.md, CHANGELOG.md) to reflect unified versioning

## Test plan
- [ ] Verify CI passes (no `-dev` check step needed)
- [ ] Verify `./scripts/bump-version.sh 3.21.0` still works correctly
- [ ] Confirm no remaining `-dev` version suffix references in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)