### PR TITLE
feat(website): update landing page for v3.21.0

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Jaan.to — Give your product work a soul</title>
+    <title>Jaan.to — Give soul to your ideas!</title>
     <meta name="description" content="Jaan.to is a workflow layer for Claude Code. AI handles the repetitive work. Humans keep the decisions. Open source.">
     <meta name="keywords" content="Jaan.to, Claude Code, workflow automation, human-AI collaboration, product teams, open source">
 
@@ -976,15 +976,15 @@
                     <img src="favicon_io/favicon-32x32.png" alt="Jaan.to" width="24" height="24">
                     Jaan.to
                 </a>
-                <a href="https://github.com/parhumm/jaan-to/blob/main/CHANGELOG.md"
+                <a href="https://docs.jaan.to/changelog"
                    class="nav-version-badge"
                    target="_blank"
                    rel="noopener noreferrer"
-                   title="Version 3.16.2 - View changelog">v3.16.2</a>
+                   title="Version 3.21.0 - View changelog">v3.21.0</a>
             </div>
             <div class="nav-links">
-                <a href="#philosophy">Philosophy</a>
                 <a href="#skills">Skills</a>
+                <a href="https://docs.jaan.to/docs/">Documents</a>
                 <a href="https://github.com/parhumm/jaan-to" class="btn-nav">GitHub</a>
             </div>
         </div>
@@ -1129,7 +1129,7 @@
                 <div class="system-card reveal">
                     <div class="system-card-label">Skills</div>
                     <h3>What to do</h3>
-                    <p>19 structured commands across 6 roles &mdash; PM, Data, Dev, UX, Core, and QA &mdash; with Growth planned. Each skill knows its questions, its template, and its output format.</p>
+                    <p>21 structured commands across 6 roles &mdash; PM, Data, Dev, UX, Core, and QA &mdash; with Growth planned. Each skill knows its questions, its template, and its output format.</p>
                 </div>
                 <div class="system-card reveal">
                     <div class="system-card-label">Stacks</div>
@@ -1148,7 +1148,7 @@
                 </div>
             </div>
 
-            <p class="system-stats reveal">19 skills available now. 6 active roles. 1 more role planned.</p>
+            <p class="system-stats reveal">21 skills available now. 6 active roles. 1 more role planned.</p>
         </div>
     </section>
 
@@ -1239,6 +1239,18 @@
                             <code class="catalog-skill-command">/jaan-to:dev-fe-design</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Create distinctive frontend component code</span>
+                        </li>
+                        <li class="catalog-skill">
+                            <span class="catalog-skill-dot"></span>
+                            <code class="catalog-skill-command">/jaan-to:dev-api-contract</code>
+                            <span class="catalog-skill-sep">&mdash;</span>
+                            <span class="catalog-skill-desc">Generate OpenAPI 3.1 API contracts</span>
+                        </li>
+                        <li class="catalog-skill">
+                            <span class="catalog-skill-dot"></span>
+                            <code class="catalog-skill-command">/jaan-to:dev-be-data-model</code>
+                            <span class="catalog-skill-sep">&mdash;</span>
+                            <span class="catalog-skill-desc">Generate data model documentation</span>
                         </li>
                     </ul>
                 </div>
@@ -1366,7 +1378,7 @@
             <div class="vision-horizons">
                 <div class="horizon horizon-now reveal">
                     <div class="horizon-label">Now</div>
-                    <p>19 production skills. Learning system that improves from feedback. Two-phase workflow with human approval. Open source, MIT licensed.</p>
+                    <p>21 production skills. Learning system that improves from feedback. Two-phase workflow with human approval. Open source, MIT licensed.</p>
                 </div>
                 <div class="horizon horizon-next reveal">
                     <div class="horizon-label">Next</div>
@@ -1400,7 +1412,7 @@
 
             <div class="cta-actions reveal">
                 <a href="https://github.com/parhumm/jaan-to" class="btn btn-primary">Get Started on GitHub</a>
-                <a href="https://github.com/parhumm/jaan-to/blob/main/docs/README.md" class="btn btn-secondary">Read the Docs</a>
+                <a href="https://docs.jaan.to/docs/" class="btn btn-secondary">Read the Docs</a>
             </div>
 
             <div class="cta-creator reveal">
@@ -1424,9 +1436,9 @@
             <div class="footer-col">
                 <h4>Product</h4>
                 <a href="https://github.com/parhumm/jaan-to">GitHub</a>
-                <a href="https://github.com/parhumm/jaan-to/blob/main/docs/README.md">Documentation</a>
-                <a href="https://github.com/parhumm/jaan-to/blob/main/docs/roadmap/roadmap.md">Roadmap</a>
-                <a href="https://github.com/parhumm/jaan-to/blob/main/CHANGELOG.md">Changelog</a>
+                <a href="https://docs.jaan.to/docs/">Documentation</a>
+                <a href="https://docs.jaan.to/docs/roadmap/">Roadmap</a>
+                <a href="https://docs.jaan.to/changelog">Changelog</a>
             </div>
             <div class="footer-col">
                 <h4>Philosophy</h4>


### PR DESCRIPTION
## Summary
- Updated tagline to "Give soul to your ideas!"
- Bumped version badge from v3.16.2 to v3.21.0
- Added 2 new dev skills (dev-api-contract, dev-be-data-model) bringing total to 21
- Migrated docs, changelog, and roadmap links from GitHub to docs.jaan.to
- Replaced Philosophy nav link with Documents link

## Test plan
- [ ] Verify landing page renders correctly
- [ ] Confirm all docs.jaan.to links resolve
- [ ] Check version badge shows v3.21.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)