### PR TITLE
feat(skills): add language settings to all 21 skills

### DIFF
--- a/jaan-to/config/settings.yaml
+++ b/jaan-to/config/settings.yaml
@@ -21,6 +21,9 @@ version: "3.0"
 # Options: merge (combine plugin + project), override (project only)
 learning_strategy: "merge"
 
+# Language preference for conversation and output
+language: "en"
+
 # Tech Stack Configuration
 # Edit jaan-to/context/tech.md to define your project's tech stack
 # Skills will automatically reference it in generated outputs

--- a/skills/data-gtm-datalayer/SKILL.md
+++ b/skills/data-gtm-datalayer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: data-gtm-datalayer
 description: Generate production-ready GTM tracking code (dataLayer pushes and HTML attributes).
-allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**)
+allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**), Edit(jaan-to/config/settings.yaml)
 argument-hint: [prd-path | tracking-description | (interactive)]
 ---
 
@@ -36,6 +36,25 @@ If the file exists, apply its lessons throughout this execution:
 - Avoid items in "Common Mistakes"
 
 If the file does not exist, continue without it.
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_data-gtm-datalayer` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
+
+> **Language exception**: Generated code output (variable names, code blocks, schemas, SQL, API specs) is NOT affected by this setting and remains in the project's programming language.
 
 ---
 

--- a/skills/dev-api-contract/SKILL.md
+++ b/skills/dev-api-contract/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-api-contract
 description: Generate OpenAPI 3.1 contracts with schemas, RFC 9457 errors, versioning, and examples from API entities.
-allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task, WebSearch, AskUserQuestion
+allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
 argument-hint: [entities-or-prd-path]
 ---
 
@@ -46,6 +46,25 @@ If the file does not exist, continue without it.
 
 Also read tech context if available:
 - `$JAAN_CONTEXT_DIR/tech.md` - Know the tech stack for framework-specific patterns (versioning, auth, error format)
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_dev-api-contract` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
+
+> **Language exception**: Generated code output (variable names, code blocks, schemas, SQL, API specs) is NOT affected by this setting and remains in the project's programming language.
 
 ---
 

--- a/skills/dev-be-data-model/SKILL.md
+++ b/skills/dev-be-data-model/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-be-data-model
 description: Generate data model docs with tables, constraints, indexes, retention, and migration notes from entities.
-allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task, AskUserQuestion
+allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
 argument-hint: [entities-or-prd-path]
 ---
 
@@ -46,6 +46,25 @@ If the file does not exist, continue without it.
 
 Also read tech context (CRITICAL for this skill):
 - `$JAAN_CONTEXT_DIR/tech.md` - Determines database engine, constraints, common patterns
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_dev-be-data-model` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
+
+> **Language exception**: Generated code output (variable names, code blocks, schemas, SQL, API specs) is NOT affected by this setting and remains in the project's programming language.
 
 ---
 

--- a/skills/dev-be-task-breakdown/SKILL.md
+++ b/skills/dev-be-task-breakdown/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-be-task-breakdown
 description: Convert a PRD into structured backend development tasks with data model notes, reliability patterns, and error taxonomy.
-allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task
+allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task, Edit(jaan-to/config/settings.yaml)
 argument-hint: [prd-path] OR [feature-description]
 ---
 
@@ -45,6 +45,25 @@ If the file does not exist, continue without it.
 
 Also read tech context (CRITICAL for this skill):
 - `$JAAN_CONTEXT_DIR/tech.md` - Determines framework (Laravel, FastAPI, Django, etc.), constraints, patterns
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_dev-be-task-breakdown` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
+
+> **Language exception**: Generated code output (variable names, code blocks, schemas, SQL, API specs) is NOT affected by this setting and remains in the project's programming language.
 
 ---
 

--- a/skills/dev-fe-design/SKILL.md
+++ b/skills/dev-fe-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-fe-design
 description: Create distinctive, production-grade frontend interfaces with bold design choices and working code.
-allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task, WebSearch, AskUserQuestion
+allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
 argument-hint: [component-description-or-requirements]
 ---
 
@@ -49,6 +49,25 @@ Also read context files if available:
 - `$JAAN_CONTEXT_DIR/tech.md` - Know the tech stack for framework-specific code generation
 - `$JAAN_CONTEXT_DIR/design.md` - Know the design system patterns
 - `$JAAN_CONTEXT_DIR/brand.md` - Know brand colors, fonts, tone
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_dev-fe-design` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
+
+> **Language exception**: Generated code output (variable names, code blocks, schemas, SQL, API specs) is NOT affected by this setting and remains in the project's programming language.
 
 ---
 

--- a/skills/dev-fe-task-breakdown/SKILL.md
+++ b/skills/dev-fe-task-breakdown/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-fe-task-breakdown
 description: Generate frontend task breakdowns from UX handoffs with component inventory, state matrices, and estimates.
-allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task, WebSearch, AskUserQuestion
+allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
 argument-hint: [ux-handoff-description-or-figma-link]
 ---
 
@@ -47,6 +47,25 @@ If the file does not exist, continue without it.
 
 Also read tech context if available:
 - `$JAAN_CONTEXT_DIR/tech.md` - Know the tech stack for framework-specific patterns
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_dev-fe-task-breakdown` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
+
+> **Language exception**: Generated code output (variable names, code blocks, schemas, SQL, API specs) is NOT affected by this setting and remains in the project's programming language.
 
 ---
 

--- a/skills/dev-stack-detect/SKILL.md
+++ b/skills/dev-stack-detect/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dev-stack-detect
 description: Auto-detect project tech stack and populate jaan.to context files.
-allowed-tools: Read, Glob, Grep, Bash(git remote:*), Bash(ls:*), Write($JAAN_CONTEXT_DIR/**), Edit($JAAN_CONTEXT_DIR/**), Write($JAAN_OUTPUTS_DIR/dev/**)
+allowed-tools: Read, Glob, Grep, Bash(git remote:*), Bash(ls:*), Write($JAAN_CONTEXT_DIR/**), Edit($JAAN_CONTEXT_DIR/**), Write($JAAN_OUTPUTS_DIR/dev/**), Edit(jaan-to/config/settings.yaml)
 argument-hint: [optional-focus-area]
 ---
 
@@ -38,6 +38,25 @@ If the file exists, apply its lessons throughout this execution:
 - Avoid mistakes listed in "Common Mistakes"
 
 If the file does not exist, continue without it.
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_dev-stack-detect` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
+
+> **Language exception**: Generated code output (variable names, code blocks, schemas, SQL, API specs) is NOT affected by this setting and remains in the project's programming language.
 
 ---
 

--- a/skills/docs-create/SKILL.md
+++ b/skills/docs-create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docs-create
 description: Create new documentation with templates following STYLE.md.
-allowed-tools: Read, Glob, Grep, Write(docs/**), Write($JAAN_OUTPUTS_DIR/**), Bash(git add:*), Bash(git commit:*)
+allowed-tools: Read, Glob, Grep, Write(docs/**), Write($JAAN_OUTPUTS_DIR/**), Bash(git add:*), Bash(git commit:*), Edit(jaan-to/config/settings.yaml)
 argument-hint: "{type} {name}"
 ---
 
@@ -31,6 +31,23 @@ If the file exists, apply its lessons throughout this execution:
 - Avoid items in "Common Mistakes"
 
 If the file does not exist, continue without it.
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_docs-create` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
 
 ---
 

--- a/skills/docs-update/SKILL.md
+++ b/skills/docs-update/SKILL.md
@@ -28,6 +28,23 @@ If the file exists, apply its lessons throughout this execution:
 
 If the file does not exist, continue without it.
 
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_docs-update` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
+
 ---
 
 ## File Mapping (Code → Docs)

--- a/skills/learn-add/SKILL.md
+++ b/skills/learn-add/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: learn-add
 description: Add a lesson to a skill's LEARN.md file, routing feedback to skill, template, or context learning.
-allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**), Bash(git add:*), Bash(git commit:*)
+allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**), Bash(git add:*), Bash(git commit:*), Edit(jaan-to/config/settings.yaml)
 argument-hint: "[target] [lesson]"
 ---
 
@@ -27,6 +27,27 @@ Examples:
 - `/jaan-to:learn-add "$JAAN_CONTEXT_DIR/tech" "All new tables need soft delete"`
 
 If no input provided, ask for target and lesson.
+
+---
+
+## Pre-Execution
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_learn-add` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
 
 ---
 

--- a/skills/pm-prd-write/SKILL.md
+++ b/skills/pm-prd-write/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pm-prd-write
 description: Generate a Product Requirements Document from an initiative description.
-allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**)
+allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**), Edit(jaan-to/config/settings.yaml)
 argument-hint: [initiative-description]
 hooks:
   PreToolUse:
@@ -49,6 +49,23 @@ Also read context files if available:
 - `$JAAN_CONTEXT_DIR/team.md` - Know team structure and norms
 
 If the file does not exist, continue without it.
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_pm-prd-write` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
 
 ---
 

--- a/skills/pm-research-about/SKILL.md
+++ b/skills/pm-research-about/SKILL.md
@@ -34,6 +34,23 @@ If the file exists, apply its lessons throughout this execution:
 
 If the file does not exist, continue without it.
 
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_pm-research-about` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
+
 ---
 
 # PHASE 0: Input Validation

--- a/skills/pm-story-write/SKILL.md
+++ b/skills/pm-story-write/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pm-story-write
 description: Generate user stories with Given/When/Then acceptance criteria following INVEST principles.
-allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**), Task
+allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**), Task, Edit(jaan-to/config/settings.yaml)
 argument-hint: [feature] [persona] [goal] OR [epic-id]
 ---
 
@@ -56,6 +56,23 @@ Also optionally reference research insights:
 - Splitting patterns if needed (Section 3)
 
 If files don't exist, continue without them.
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_pm-story-write` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
 
 ---
 

--- a/skills/qa-test-cases/SKILL.md
+++ b/skills/qa-test-cases/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: qa-test-cases
 description: Generate production-ready BDD/Gherkin test cases from acceptance criteria using ISTQB techniques.
-allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/qa/**), Task, WebSearch
+allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/qa/**), Task, WebSearch, Edit(jaan-to/config/settings.yaml)
 argument-hint: [acceptance-criteria | prd-path | jira-id | (interactive)]
 ---
 
@@ -54,6 +54,23 @@ This provides:
 - AI failure mode mitigation patterns (Section 8)
 
 If files do not exist, continue without them.
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_qa-test-cases` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
 
 ---
 

--- a/skills/roadmap-add/SKILL.md
+++ b/skills/roadmap-add/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: roadmap-add
 description: "[Internal] Add a task to the jaan.to development roadmap."
-allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**)
+allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**), Edit(jaan-to/config/settings.yaml)
 argument-hint: [task-description]
 ---
 
@@ -35,6 +35,23 @@ If the file exists, apply its lessons throughout this execution:
 - Avoid items in "Common Mistakes"
 
 If the file does not exist, continue without it.
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_roadmap-add` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
 
 ---
 

--- a/skills/roadmap-update/SKILL.md
+++ b/skills/roadmap-update/SKILL.md
@@ -44,6 +44,23 @@ If input doesn't match any pattern, ask: "Which mode? [smart-default / mark / re
 If the file exists, apply its lessons throughout this execution.
 If the file does not exist, continue without it.
 
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_roadmap-update` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
+
 ---
 
 # PHASE 1: Analysis (Read-Only)

--- a/skills/skill-create/SKILL.md
+++ b/skills/skill-create/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill-create
 description: Guide users through creating new jaan.to skills step-by-step.
-allowed-tools: Read, Glob, Grep, Task, WebSearch, Write(skills/**), Write(docs/**), Write($JAAN_OUTPUTS_DIR/**), Edit($JAAN_TEMPLATES_DIR/**), Edit($JAAN_LEARN_DIR/**), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(gh pr create:*)
+allowed-tools: Read, Glob, Grep, Task, WebSearch, Write(skills/**), Write(docs/**), Write($JAAN_OUTPUTS_DIR/**), Edit($JAAN_TEMPLATES_DIR/**), Edit($JAAN_LEARN_DIR/**), Edit(jaan-to/config/settings.yaml), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(gh pr create:*)
 argument-hint: [optional-skill-idea]
 ---
 
@@ -45,6 +45,23 @@ If the file exists, apply its lessons throughout this execution:
 - ✗ Not validating with `/jaan-to:skill-update` before user testing
 
 If the file does not exist, continue without it (but still avoid mistakes above).
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_skill-create` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
 
 ---
 
@@ -432,7 +449,7 @@ Write to: `skills/{name}/SKILL.md`
 
 **Standard pattern for all skills**:
 ```markdown
-## Pre-Execution
+## Pre-Execution: Apply Past Lessons
 
 **MANDATORY FIRST ACTION** — Before any other step, use the Read tool to read:
 `$JAAN_LEARN_DIR/{skill-name}.learn.md`
@@ -442,9 +459,33 @@ If the file exists, apply its lessons throughout this execution:
 - Note edge cases to check from "Edge Cases"
 - Follow workflow improvements from "Workflow"
 - Avoid mistakes listed in "Common Mistakes"
+
+If the file does not exist, continue without it.
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_{skill-name}` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
 ```
 
-**For tech-aware skills, add**:
+**For skills that generate code, add after Language Settings**:
+```markdown
+> **Language exception**: Generated code output (variable names, code blocks, schemas, SQL, API specs) is NOT affected by this setting and remains in the project's programming language.
+```
+
+**For tech-aware skills, add before Language Settings**:
 ```markdown
 Also read tech context if available:
 - `$JAAN_CONTEXT_DIR/tech.md` - Know the tech stack for relevant features
@@ -648,6 +689,9 @@ Before completing Step 12, verify:
 - [ ] Frontmatter permissions use environment variables
 - [ ] Context Files section references `$JAAN_CONTEXT_DIR`, `$JAAN_TEMPLATES_DIR`, `$JAAN_LEARN_DIR`
 - [ ] Pre-Execution reads from `$JAAN_LEARN_DIR/{skill-name}.learn.md`
+- [ ] Pre-Execution includes Language Settings block (reads `jaan-to/config/settings.yaml`)
+- [ ] `allowed-tools` includes `Edit(jaan-to/config/settings.yaml)`
+- [ ] If skill generates code, Language exception note is present
 - [ ] Output paths use `$JAAN_OUTPUTS_DIR`
 - [ ] template.md uses variable syntax: `{{field}}`, `{{env:VAR}}`, `{{import:path#section}}`
 

--- a/skills/skill-update/SKILL.md
+++ b/skills/skill-update/SKILL.md
@@ -38,6 +38,23 @@ If the file exists, apply its lessons throughout this execution:
 
 If the file does not exist, continue without it.
 
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_skill-update` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
+
 ---
 
 # PHASE 0: Git Branch Setup

--- a/skills/ux-heatmap-analyze/SKILL.md
+++ b/skills/ux-heatmap-analyze/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ux-heatmap-analyze
 description: Analyze heatmap data from CSV exports and screenshots to generate prioritized UX research reports.
-allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/**)
+allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/**), Edit(jaan-to/config/settings.yaml)
 argument-hint: [csv-path] [screenshot-path] [html-path?] [problem?]
 ---
 
@@ -43,6 +43,23 @@ If the file exists, apply its lessons throughout this execution:
 - Avoid items in "Common Mistakes"
 
 If the file does not exist, continue without it.
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_ux-heatmap-analyze` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
 
 ---
 

--- a/skills/ux-microcopy-write/SKILL.md
+++ b/skills/ux-microcopy-write/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ux-microcopy-write
 description: Generate multi-language microcopy packs for UI components with cultural adaptation and RTL/LTR handling.
-allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/**), Write($JAAN_CONTEXT_DIR/localization.md), Write($JAAN_CONTEXT_DIR/tone-of-voice.md), WebSearch, Task, AskUserQuestion, Bash
+allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/**), Write($JAAN_CONTEXT_DIR/localization.md), Write($JAAN_CONTEXT_DIR/tone-of-voice.md), WebSearch, Task, AskUserQuestion, Bash, Edit(jaan-to/config/settings.yaml)
 argument-hint: [initiative-or-feature-description]
 ---
 
@@ -37,6 +37,25 @@ If the file exists, apply its lessons throughout this execution:
 - Avoid mistakes listed in "Common Mistakes"
 
 If the file does not exist, continue without it.
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_ux-microcopy-write` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
+
+> **Language exception**: This setting controls only plugin conversation language. The multi-language microcopy output is independently controlled by `$JAAN_CONTEXT_DIR/localization.md` and this skill's own Language Selection step.
 
 ---
 

--- a/skills/ux-research-synthesize/SKILL.md
+++ b/skills/ux-research-synthesize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ux-research-synthesize
 description: Synthesize UX research findings into themed insights, executive summaries, and prioritized recommendations.
-allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/research/**), Task, AskUserQuestion
+allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/research/**), Task, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
 argument-hint: [study-name] [data-sources?]
 ---
 
@@ -44,6 +44,23 @@ If the file exists, apply its lessons throughout this execution:
 - Avoid mistakes listed in "Common Mistakes"
 
 If the file does not exist, continue without it.
+
+### Language Settings
+
+**Read language preference** from `jaan-to/config/settings.yaml`:
+
+1. Check for per-skill override: `language_ux-research-synthesize` field
+2. If no override, use the global `language` field
+3. Resolve:
+
+| Value | Action |
+|-------|--------|
+| Language code (`en`, `fa`, `tr`, etc.) | Use that language immediately |
+| `"ask"` or field missing | Prompt: "What language do you prefer for conversation and reports?" — Options: "English" (default), "فارسی (Persian)", "Other (specify)" — then save choice to `jaan-to/config/settings.yaml` |
+
+**Keep in English always**: technical terms, code snippets, file paths, variable names, YAML keys, command names.
+
+**Apply resolved language to**: all questions, confirmations, section headings, labels, and prose in output files for this execution.
 
 ---
 


### PR DESCRIPTION
## Summary
- Added Language Settings block to all 21 SKILL.md files so every skill reads jaan-to/config/settings.yaml on execution
- Three variants: standard (13 skills), code exception for dev/data skills (7 skills), microcopy exception for ux-microcopy-write
- Added Edit(jaan-to/config/settings.yaml) to allowed-tools in 17 skills (4 already had unrestricted Edit)
- Updated skill-create template (Step 12.3) and validation checklist (Step 12.8) for future skill compliance
- Saved default language preference (en) to settings.yaml

## Test plan
- [ ] Verify all 21 skills have Language Settings block
- [ ] Verify 7 dev/data skills have Language exception note
- [ ] Run a skill with language: ask to confirm prompt appears
- [ ] Run a skill with language: en to confirm no prompt