### PR TITLE
Update website landing page for v4.5.0

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Jaan.to — Give soul to your ideas!</title>
+    <title>/Jaan-to: Give soul to your ideas</title>
     <meta name="description" content="Jaan.to is a workflow layer for Claude Code. AI handles the repetitive work. Humans keep the decisions. Open source.">
     <meta name="keywords" content="Jaan.to, Claude Code, workflow automation, human-AI collaboration, product teams, open source">
 
@@ -980,7 +980,7 @@
                    class="nav-version-badge"
                    target="_blank"
                    rel="noopener noreferrer"
-                   title="Version 3.21.0 - View changelog">v3.21.0</a>
+                   title="Version 4.5.0 - View changelog">v4.5.0</a>
             </div>
             <div class="nav-links">
                 <a href="#skills">Skills</a>
@@ -993,7 +993,7 @@
     <!-- Hero -->
     <section class="hero" id="home">
         <div>
-            <h1 class="hero-definition">/Jaan-to-*<br><em style="color:var(--color-accent)">
+            <h1 class="hero-definition">/Jaan-to:*<br><em style="color:var(--color-accent)">
             give soul to your ideas
             </em></h1>
             <!-- <h1 class="hero-definition">
@@ -1103,7 +1103,7 @@
             </div>
 
             <div class="terminal reveal">
-                <span class="prompt">$</span> <span class="command">/jaan-to:pm-prd-write "add dark mode support"</span><br><br>
+                <span class="prompt">$</span> <span class="command">/pm-prd-write "add dark mode support"</span><br><br>
                 <span class="dim">&gt; Loading context: tech.md, team.md</span><br>
                 <span class="dim">&gt; Questions before I proceed:</span><br>
                 &nbsp;&nbsp;1. What problem does dark mode solve for your users?<br>
@@ -1129,7 +1129,7 @@
                 <div class="system-card reveal">
                     <div class="system-card-label">Skills</div>
                     <h3>What to do</h3>
-                    <p>21 structured commands across 6 roles &mdash; PM, Data, Dev, UX, Core, and QA &mdash; with Growth planned. Each skill knows its questions, its template, and its output format.</p>
+                    <p>32 structured commands across 9 roles &mdash; PM, Data, Dev, UX, Core, QA, Detect, Release, and WP &mdash; with Growth planned. Each skill knows its questions, its template, and its output format.</p>
                 </div>
                 <div class="system-card reveal">
                     <div class="system-card-label">Stacks</div>
@@ -1148,7 +1148,7 @@
                 </div>
             </div>
 
-            <p class="system-stats reveal">21 skills available now. 6 active roles. 1 more role planned.</p>
+            <p class="system-stats reveal">32 skills available now. 9 active roles. 1 more role planned.</p>
         </div>
     </section>
 
@@ -1174,19 +1174,19 @@
                     <ul class="catalog-skills">
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:pm-prd-write</code>
+                            <code class="catalog-skill-command">/pm-prd-write</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Generate PRD from initiative</span>
                         </li>
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:pm-story-write</code>
+                            <code class="catalog-skill-command">/pm-story-write</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Generate user stories with Given/When/Then ACs</span>
                         </li>
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:pm-research-about</code>
+                            <code class="catalog-skill-command">/pm-research-about</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Deep research on any topic</span>
                         </li>
@@ -1202,7 +1202,7 @@
                     <ul class="catalog-skills">
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:data-gtm-datalayer</code>
+                            <code class="catalog-skill-command">/data-gtm-datalayer</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Generate GTM tracking code</span>
                         </li>
@@ -1218,39 +1218,45 @@
                     <ul class="catalog-skills">
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:detect-dev</code>
-                            <span class="catalog-skill-sep">&mdash;</span>
-                            <span class="catalog-skill-desc">Engineering audit with scored findings</span>
-                        </li>
-                        <li class="catalog-skill">
-                            <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:frontend-task-breakdown</code>
+                            <code class="catalog-skill-command">/frontend-task-breakdown</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Transform designs into frontend task breakdowns</span>
                         </li>
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:backend-task-breakdown</code>
-                            <span class="catalog-skill-sep">&mdash;</span>
-                            <span class="catalog-skill-desc">Transform specs into backend task breakdowns</span>
-                        </li>
-                        <li class="catalog-skill">
-                            <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:frontend-design</code>
+                            <code class="catalog-skill-command">/frontend-design</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Create distinctive frontend component code</span>
                         </li>
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:backend-api-contract</code>
+                            <code class="catalog-skill-command">/frontend-scaffold</code>
+                            <span class="catalog-skill-sep">&mdash;</span>
+                            <span class="catalog-skill-desc">Convert designs to React/Next.js component scaffolds</span>
+                        </li>
+                        <li class="catalog-skill">
+                            <span class="catalog-skill-dot"></span>
+                            <code class="catalog-skill-command">/backend-task-breakdown</code>
+                            <span class="catalog-skill-sep">&mdash;</span>
+                            <span class="catalog-skill-desc">Transform specs into backend task breakdowns</span>
+                        </li>
+                        <li class="catalog-skill">
+                            <span class="catalog-skill-dot"></span>
+                            <code class="catalog-skill-command">/backend-api-contract</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Generate OpenAPI 3.1 API contracts</span>
                         </li>
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:backend-data-model</code>
+                            <code class="catalog-skill-command">/backend-data-model</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Generate data model documentation</span>
+                        </li>
+                        <li class="catalog-skill">
+                            <span class="catalog-skill-dot"></span>
+                            <code class="catalog-skill-command">/backend-scaffold</code>
+                            <span class="catalog-skill-sep">&mdash;</span>
+                            <span class="catalog-skill-desc">Generate production-ready backend code with routes and services</span>
                         </li>
                     </ul>
                 </div>
@@ -1264,21 +1270,27 @@
                     <ul class="catalog-skills">
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:ux-heatmap-analyze</code>
+                            <code class="catalog-skill-command">/ux-heatmap-analyze</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Analyze heatmap CSV exports and screenshots</span>
                         </li>
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:ux-microcopy-write</code>
+                            <code class="catalog-skill-command">/ux-microcopy-write</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Generate multi-language microcopy packs</span>
                         </li>
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:ux-research-synthesize</code>
+                            <code class="catalog-skill-command">/ux-research-synthesize</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Synthesize UX research into actionable insights</span>
+                        </li>
+                        <li class="catalog-skill">
+                            <span class="catalog-skill-dot"></span>
+                            <code class="catalog-skill-command">/ux-flowchart-generate</code>
+                            <span class="catalog-skill-sep">&mdash;</span>
+                            <span class="catalog-skill-desc">Generate GitHub-renderable Mermaid flowcharts</span>
                         </li>
                     </ul>
                 </div>
@@ -1292,43 +1304,43 @@
                     <ul class="catalog-skills">
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:docs-create</code>
+                            <code class="catalog-skill-command">/docs-create</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Create documentation</span>
                         </li>
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:docs-update</code>
+                            <code class="catalog-skill-command">/docs-update</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Audit and maintain documentation</span>
                         </li>
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:learn-add</code>
+                            <code class="catalog-skill-command">/learn-add</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Add lesson to skill's LEARN.md</span>
                         </li>
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:roadmap-add</code>
+                            <code class="catalog-skill-command">/roadmap-add</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Add task to roadmap</span>
                         </li>
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:roadmap-update</code>
+                            <code class="catalog-skill-command">/roadmap-update</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Maintain and sync roadmap</span>
                         </li>
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:skill-create</code>
+                            <code class="catalog-skill-command">/skill-create</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Create new skill with wizard</span>
                         </li>
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:skill-update</code>
+                            <code class="catalog-skill-command">/skill-update</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Update existing skill</span>
                         </li>
@@ -1344,9 +1356,87 @@
                     <ul class="catalog-skills">
                         <li class="catalog-skill">
                             <span class="catalog-skill-dot"></span>
-                            <code class="catalog-skill-command">/jaan-to:qa-test-cases</code>
+                            <code class="catalog-skill-command">/qa-test-cases</code>
                             <span class="catalog-skill-sep">&mdash;</span>
                             <span class="catalog-skill-desc">Generate BDD/Gherkin test cases from acceptance criteria</span>
+                        </li>
+                    </ul>
+                </div>
+
+                <!-- Release -->
+                <div class="catalog-role reveal">
+                    <div class="catalog-role-header">
+                        <span class="catalog-role-name">Release</span>
+                        <span class="catalog-badge available">Available</span>
+                    </div>
+                    <ul class="catalog-skills">
+                        <li class="catalog-skill">
+                            <span class="catalog-skill-dot"></span>
+                            <code class="catalog-skill-command">/release-iterate-changelog</code>
+                            <span class="catalog-skill-sep">&mdash;</span>
+                            <span class="catalog-skill-desc">Generate changelogs with user impact notes from git history</span>
+                        </li>
+                    </ul>
+                </div>
+
+                <!-- Detect -->
+                <div class="catalog-role reveal">
+                    <div class="catalog-role-header">
+                        <span class="catalog-role-name">Detect</span>
+                        <span class="catalog-badge available">Available</span>
+                    </div>
+                    <ul class="catalog-skills">
+                        <li class="catalog-skill">
+                            <span class="catalog-skill-dot"></span>
+                            <code class="catalog-skill-command">/detect-dev</code>
+                            <span class="catalog-skill-sep">&mdash;</span>
+                            <span class="catalog-skill-desc">Engineering audit with OpenSSF-style scoring</span>
+                        </li>
+                        <li class="catalog-skill">
+                            <span class="catalog-skill-dot"></span>
+                            <code class="catalog-skill-command">/detect-design</code>
+                            <span class="catalog-skill-sep">&mdash;</span>
+                            <span class="catalog-skill-desc">Design system detection with drift analysis</span>
+                        </li>
+                        <li class="catalog-skill">
+                            <span class="catalog-skill-dot"></span>
+                            <code class="catalog-skill-command">/detect-writing</code>
+                            <span class="catalog-skill-sep">&mdash;</span>
+                            <span class="catalog-skill-desc">Writing system extraction with tone analysis</span>
+                        </li>
+                        <li class="catalog-skill">
+                            <span class="catalog-skill-dot"></span>
+                            <code class="catalog-skill-command">/detect-product</code>
+                            <span class="catalog-skill-sep">&mdash;</span>
+                            <span class="catalog-skill-desc">Product reality extraction with evidence model</span>
+                        </li>
+                        <li class="catalog-skill">
+                            <span class="catalog-skill-dot"></span>
+                            <code class="catalog-skill-command">/detect-ux</code>
+                            <span class="catalog-skill-sep">&mdash;</span>
+                            <span class="catalog-skill-desc">UX audit with route extraction and heuristics</span>
+                        </li>
+                        <li class="catalog-skill">
+                            <span class="catalog-skill-dot"></span>
+                            <code class="catalog-skill-command">/detect-pack</code>
+                            <span class="catalog-skill-sep">&mdash;</span>
+                            <span class="catalog-skill-desc">Consolidate detect outputs into knowledge index</span>
+                        </li>
+                    </ul>
+                </div>
+
+                <!-- WP -->
+                <div class="catalog-role reveal">
+                    <div class="catalog-role-header">
+                        <span class="catalog-role-name">WP</span>
+                        <span class="catalog-badge available">Available</span>
+                    </div>
+                    <ul class="catalog-skills">
+                        <li class="catalog-skill">
+                            <span class="catalog-skill-dot"></span>
+                            <code class="catalog-skill-command">/wp-pr-review</code>
+                            <span class="catalog-skill-sep">&mdash;</span>
+                            <span class="catalog-skill-desc">Review WordPress plugin PRs for security and standards</span>
                         </li>
                     </ul>
                 </div>
@@ -1378,11 +1468,11 @@
             <div class="vision-horizons">
                 <div class="horizon horizon-now reveal">
                     <div class="horizon-label">Now</div>
-                    <p>21 production skills. Learning system that improves from feedback. Two-phase workflow with human approval. Open source, MIT licensed.</p>
+                    <p>32 production skills. Learning system that improves from feedback. Two-phase workflow with human approval. Open source, MIT licensed.</p>
                 </div>
                 <div class="horizon horizon-next reveal">
                     <div class="horizon-label">Next</div>
-                    <p>30+ skills across 7 product roles. MCP connectors to real systems &mdash; Figma, Jira, GA4, Sentry, Clarity, and more.</p>
+                    <p>35+ skills across 8 product roles. MCP connectors to real systems &mdash; Figma, Jira, GA4, Sentry, Clarity, and more.</p>
                 </div>
                 <div class="horizon horizon-ahead reveal">
                     <div class="horizon-label">Ahead</div>
@@ -1407,7 +1497,7 @@
                 <span class="prompt">$</span> <span class="command">claude</span><br>
                 <span class="prompt">$</span> <span class="command">/plugin marketplace add parhumm/jaan-to</span><br>
                 <span class="prompt">$</span> <span class="command">/plugin install jaan-to/jaan-to</span><br>
-                <span class="prompt">$</span> <span class="command">/jaan-to:pm-prd-write "your first feature"</span>
+                <span class="prompt">$</span> <span class="command">/frontend-design "A landingpage for Personal Branding"</span>
             </div>
 
             <div class="cta-actions reveal">


### PR DESCRIPTION
## Summary
- Updated skill catalog from 21 to 32 skills across 9 roles (was 6)
- Simplified skill command display (removed `/jaan-to:` prefix)
- Added new Release, Detect, and WP role sections
- Bumped displayed version to v4.5.0
- Updated vision/roadmap stats to reflect current state

## Test plan
- [ ] Verify landing page renders correctly
- [ ] Check all skill command names display properly
- [ ] Confirm version badge shows v4.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)