### PR TITLE
fix(config): correct seed settings.yaml default path examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Template/learn naming mismatch** — Bootstrap created files as `{skill}.template.md` / `{skill}.learn.md` (without `jaan-to:` prefix) but all 38 skills expected `jaan-to:{skill}.template.md` / `jaan-to:{skill}.learn.md`. Eagerly-copied files were never found by skills. The pre-execution protocol and path-resolver now support both naming conventions for backward compatibility.
+- **Seed settings.yaml showed wrong default paths** — Commented-out path examples showed `artifacts/jaan-to` instead of actual default `jaan-to/outputs` (and similar mismatches for templates, learning, context). Existing projects auto-corrected on next session via bootstrap migration. Fixes [#64](https://github.com/parhumm/jaan-to/issues/64)
 
 ---
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -67,6 +67,17 @@ if [ ! -f "$PROJECT_DIR/$CONFIG_DIR/settings.yaml" ]; then
   fi
 fi
 
+# 3.5. Migration: fix wrong default path examples in settings.yaml (issue #64)
+if [ -f "$PROJECT_DIR/$CONFIG_DIR/settings.yaml" ] && grep -q 'artifacts/jaan-to' "$PROJECT_DIR/$CONFIG_DIR/settings.yaml" 2>/dev/null; then
+  sed -i.bak \
+    -e 's|# paths_templates: "docs/templates"|# paths_templates: "jaan-to/templates"|' \
+    -e 's|# paths_learning: "docs/learning"|# paths_learning: "jaan-to/learn"|' \
+    -e 's|# paths_context: "docs/context"|# paths_context: "jaan-to/context"|' \
+    -e 's|# paths_outputs: "artifacts/jaan-to"|# paths_outputs: "jaan-to/outputs"|' \
+    -e 's|# Uncomment and modify to change default locations|# These are the defaults — uncomment and modify to change locations|' \
+    "$PROJECT_DIR/$CONFIG_DIR/settings.yaml" && rm -f "$PROJECT_DIR/$CONFIG_DIR/settings.yaml.bak"
+fi
+
 # 4. Copy context files (skip if exists)
 if [ -d "$PLUGIN_DIR/scripts/seeds" ]; then
   for context_file in "$PLUGIN_DIR/scripts/seeds"/*.md; do

--- a/scripts/seeds/settings.yaml
+++ b/scripts/seeds/settings.yaml
@@ -6,11 +6,11 @@
 version: "3.0"
 
 # Path Customization
-# Uncomment and modify to change default locations
-# paths_templates: "docs/templates"
-# paths_learning: "docs/learning"
-# paths_context: "docs/context"
-# paths_outputs: "artifacts/jaan-to"
+# These are the defaults — uncomment and modify to change locations
+# paths_templates: "jaan-to/templates"
+# paths_learning: "jaan-to/learn"
+# paths_context: "jaan-to/context"
+# paths_outputs: "jaan-to/outputs"
 
 # Template Customization
 # Uncomment to use custom template files


### PR DESCRIPTION
## Summary
- Seed `settings.yaml` showed wrong commented-out path defaults (`artifacts/jaan-to` instead of `jaan-to/outputs`, and similar mismatches for templates, learning, context)
- All four path examples now match `config/defaults.yaml` actual defaults
- Bootstrap migration auto-fixes existing project settings on next session start (idempotent, only touches commented lines)

Closes #64

## Test plan
- [ ] Verify seed file commented values match `config/defaults.yaml`
- [ ] Run `build-dist.sh` and confirm dist seed has fix
- [ ] Confirm migration is a no-op on already-fixed settings files
- [ ] Verify bootstrap runs cleanly (config-loader skips commented lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)