### PR TITLE
fix(protocol): add Step 0 initialization guard to pre-execution protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Pre-execution protocol adds initialization guard (Step 0)** ([#87](https://github.com/parhumm/jaan-to/issues/87)) — All skills now actively check for `jaan-to/` directory before executing and recommend `/jaan-init` if missing. Prevents partial directory creation and degraded output on uninitialized projects. Skips for `jaan-init` itself to avoid circular dependency. Complements the bootstrap hook message from v6.2.1 with invocation-level enforcement.
+
 ---
 
 ## [6.2.1] - 2026-02-14

--- a/docs/extending/pre-execution-protocol.md
+++ b/docs/extending/pre-execution-protocol.md
@@ -1,6 +1,23 @@
 # Pre-Execution Protocol
 
-**MANDATORY FIRST ACTION** — Before any other step, load lessons and resolve the template for this skill.
+**MANDATORY FIRST ACTION** — Before any other step, check project initialization, load lessons, and resolve the template for this skill.
+
+## Step 0: Initialization Guard
+
+**Skip this step** if the current skill is `jaan-init`.
+
+Check if the `jaan-to/` directory exists in the project root.
+
+**If `jaan-to/` exists** → proceed to Step A.
+
+**If `jaan-to/` does NOT exist** → the project has not been initialized. Ask the user:
+
+> "This project hasn't been initialized with jaan-to yet. Context files and configuration won't be available, which may reduce output quality. Run `/jaan-init` to set up the project first?"
+>
+> Options: [1] Yes, run /jaan-init first (Recommended) — [2] No, continue without initialization
+
+- **Option 1**: Run `/jaan-init` and follow its full workflow. After initialization completes, return here and continue from Step A.
+- **Option 2**: Continue to Step A. Skills will operate with plugin defaults only (no project-specific context).
 
 ## Step A: Load Lessons
 


### PR DESCRIPTION
## Summary
- Add Step 0 (Initialization Guard) to `pre-execution-protocol.md` before Step A
- All 38 skills now actively check for `jaan-to/` directory at invocation time
- If missing, prompts user to run `/jaan-init` first (with option to skip)
- Skips for `jaan-init` itself to avoid circular dependency
- Complements the bootstrap hook message (v6.2.1) with invocation-level enforcement

## Issue
Closes #87 (regression — bootstrap-only fix was insufficient)

## Changes
- `docs/extending/pre-execution-protocol.md` — Added Step 0: Initialization Guard
- `CHANGELOG.md` — Entry under [Unreleased]

## Verification
- [x] Skill budget: 7,802 / 15,000 (unchanged)
- [x] No individual skill modifications needed
- [x] `jaan-init` exemption present
- [x] CHANGELOG.md updated

Co-Authored-By: Claude <noreply@anthropic.com>