### PR TITLE
fix: remove automatic .gitignore policy from bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Removed automatic `.gitignore` policy from bootstrap** — Bootstrap no longer auto-adds `jaan-to/` to the project's `.gitignore` on every session start. Instead, `/jaan-to:jaan-init` now asks users during initialization whether to add `jaan-to/` to `.gitignore`, with the recommendation being **no** (commit `jaan-to/` to version control). Updated `bootstrap.sh`, `verify-install.sh`, `jaan-init` SKILL.md, and all related documentation
 - **Roadmap-update now enforces 6 structural consistency rules** — Every run validates overview-to-section matching, sequential numbering, done-phase blockquotes, catalog accuracy, version accuracy, and future-focus compliance. Violations are reported before mode-specific work begins
 - **Release-iterate-changelog now triggers roadmap sync** — After writing changelog updates, the skill calls `/jaan-to:roadmap-update` to keep the roadmap in sync automatically
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ jaan.to runs a bootstrap script automatically on your first session. This create
 
 - `jaan-to/outputs/` directory for generated files
 - `jaan-to/learn/` directory for accumulated knowledge
-- `jaan-to/.gitignore` to exclude temporary files
 
 ### Optional: Customize Context
 
@@ -309,16 +308,7 @@ jaan-to/
 │   └── research/{slug}/report.md
 ├── learn/
 │   └── LEARN.md
-└── .gitignore
 ```
-
-**Recommended `.gitignore` entry:**
-```
-jaan-to/outputs/
-jaan-to/temp/
-```
-
-jaan.to automatically creates `jaan-to/.gitignore` with sensible defaults on first run.
 
 ---
 

--- a/docs/hooks/bootstrap.md
+++ b/docs/hooks/bootstrap.md
@@ -46,13 +46,12 @@ This message flows through the `SessionStart` hook into the conversation context
    - `jaan-to/templates/`
    - `jaan-to/config/`
    - `jaan-to/docs/`
-3. **Manages `.gitignore`** — Adds `jaan-to/` to `.gitignore` if not present. Creates `.gitignore` if it doesn't exist.
-4. **Seeds config** — Copies `settings.yaml` from `scripts/seeds/` to `jaan-to/config/` if not present.
-5. **Copies context files** — Copies `.md` seed files from `scripts/seeds/` to `jaan-to/context/` (skips existing).
+3. **Seeds config** — Copies `settings.yaml` from `scripts/seeds/` to `jaan-to/config/` if not present.
+4. **Copies context files** — Copies `.md` seed files from `scripts/seeds/` to `jaan-to/context/` (skips existing).
 
 > **Note**: Templates, learn files, and reference docs (STYLE.md, create-skill.md) are **not** copied during bootstrap. They are loaded from the plugin at runtime (lazy loading). Project-level overrides can be created in `jaan-to/templates/` for templates and via `/jaan-to:learn-add` for learn files.
-6. **Checks context seeds** — Verifies expected seed files (`tech.md`, `team.md`, `integrations.md`, `config.md`, `boundaries.md`) exist in the plugin.
-7. **Suggests detect skills** — If `tech.md` still contains `{project-name}` placeholder, suggests running `/jaan-to:detect-pack` to perform full repo analysis.
+5. **Checks context seeds** — Verifies expected seed files (`tech.md`, `team.md`, `integrations.md`, `config.md`, `boundaries.md`) exist in the plugin.
+6. **Suggests detect skills** — If `tech.md` still contains `{project-name}` placeholder, suggests running `/jaan-to:detect-pack` to perform full repo analysis.
 
 ---
 
@@ -61,8 +60,6 @@ This message flows through the `SessionStart` hook into the conversation context
 | Result | Condition | Action |
 |--------|-----------|--------|
 | Creates directories | Any missing | Creates all required directories listed above |
-| Appends to gitignore | `.gitignore` exists without entry | Appends `jaan-to/` |
-| Creates gitignore | No `.gitignore` exists | Creates file with `jaan-to/` |
 | Seeds config | `jaan-to/config/settings.yaml` missing | Copies from plugin seeds |
 | Seeds context | Context `.md` files missing | Copies from `scripts/seeds/` |
 | Skips copy | Any destination file already exists | Preserves existing files |

--- a/docs/skills/core/jaan-init.md
+++ b/docs/skills/core/jaan-init.md
@@ -53,7 +53,7 @@ jaan-to/
   docs/                    — Reference docs (STYLE.md, create-skill.md)
 ```
 
-Also adds `jaan-to/` to `.gitignore` (creates the file if missing).
+Optionally adds `jaan-to/` to `.gitignore` if the user chooses during init (recommended: no).
 
 ---
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -49,16 +49,7 @@ mkdir -p "$PROJECT_DIR/$TEMPLATES_DIR"
 mkdir -p "$PROJECT_DIR/$CONFIG_DIR"
 mkdir -p "$PROJECT_DIR/$DOCS_DIR"
 
-# 2. Add to .gitignore if not present
-if [ -f "$PROJECT_DIR/.gitignore" ]; then
-  if ! grep -q "jaan-to/" "$PROJECT_DIR/.gitignore" 2>/dev/null; then
-    echo "jaan-to/" >> "$PROJECT_DIR/.gitignore"
-  fi
-else
-  echo "jaan-to/" > "$PROJECT_DIR/.gitignore"
-fi
-
-# 3. Initialize project config if not exists
+# 2. Initialize project config if not exists
 if [ ! -f "$PROJECT_DIR/$CONFIG_DIR/settings.yaml" ]; then
   if [ -f "$PLUGIN_DIR/scripts/seeds/settings.yaml" ]; then
     cp "$PLUGIN_DIR/scripts/seeds/settings.yaml" "$PROJECT_DIR/$CONFIG_DIR/settings.yaml"

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -79,15 +79,10 @@ if [ -n "$PLUGIN_DIR" ] && [ -d "$PLUGIN_DIR/docs" ]; then
   check "$([ -f "$PLUGIN_DIR/docs/extending/create-skill.md" ] && echo true || echo false)" "Plugin has create-skill.md"
 fi
 
-# 6. .gitignore
-echo ""
-echo "6. .gitignore:"
-check "$(grep -q 'jaan-to/' "$PROJECT_DIR/.gitignore" 2>/dev/null && echo true || echo false)" "jaan-to in .gitignore"
-
-# 7. Plugin manifest validation (if plugin dir available)
+# 6. Plugin manifest validation (if plugin dir available)
 if [ -n "$PLUGIN_DIR" ] && [ -d "$PLUGIN_DIR" ]; then
   echo ""
-  echo "7. Plugin manifest:"
+  echo "6. Plugin manifest:"
   check "$([ -f "$PLUGIN_DIR/.claude-plugin/plugin.json" ] && echo true || echo false)" "plugin.json exists"
   check "$([ -f "$PLUGIN_DIR/.claude-plugin/marketplace.json" ] && echo true || echo false)" "marketplace.json exists"
 
@@ -104,10 +99,10 @@ if [ -n "$PLUGIN_DIR" ] && [ -d "$PLUGIN_DIR" ]; then
   fi
 fi
 
-# 8. Hooks validation (if plugin dir available)
+# 7. Hooks validation (if plugin dir available)
 if [ -n "$PLUGIN_DIR" ] && [ -d "$PLUGIN_DIR" ]; then
   echo ""
-  echo "8. Hooks:"
+  echo "7. Hooks:"
   check "$([ -f "$PLUGIN_DIR/hooks/hooks.json" ] && echo true || echo false)" "hooks/hooks.json exists"
 
   if command -v jq >/dev/null 2>&1 && [ -f "$PLUGIN_DIR/hooks/hooks.json" ]; then
@@ -120,10 +115,10 @@ if [ -n "$PLUGIN_DIR" ] && [ -d "$PLUGIN_DIR" ]; then
   fi
 fi
 
-# 9. Skills validation (if plugin dir available)
+# 8. Skills validation (if plugin dir available)
 if [ -n "$PLUGIN_DIR" ] && [ -d "$PLUGIN_DIR/skills" ]; then
   echo ""
-  echo "9. Skills (plugin directory):"
+  echo "8. Skills (plugin directory):"
 
   skill_count=0
   skill_with_frontmatter=0
@@ -144,9 +139,9 @@ if [ -n "$PLUGIN_DIR" ] && [ -d "$PLUGIN_DIR/skills" ]; then
   fi
 fi
 
-# 10. Configuration loading test
+# 9. Configuration loading test
 echo ""
-echo "10. Configuration files (markdown syntax):"
+echo "9. Configuration files (markdown syntax):"
 
 config_files=(
   "jaan-to/context/config.md"
@@ -163,9 +158,9 @@ for config_file in "${config_files[@]}"; do
   fi
 done
 
-# 11. Installation report
+# 10. Installation report
 echo ""
-echo "11. Installation Summary:"
+echo "10. Installation Summary:"
 
 # Count files created
 total_files=$(find "$PROJECT_DIR/jaan-to" -type f 2>/dev/null | wc -l | tr -d ' ')

--- a/skills/jaan-init/SKILL.md
+++ b/skills/jaan-init/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: jaan-init
 description: Initialize jaan-to for the current project with directory setup and seed files.
-allowed-tools: Read, Bash(${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.sh)
+allowed-tools: Read, Bash(${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.sh), Edit(.gitignore)
 argument-hint: (no arguments)
 disable-model-invocation: true
 ---
@@ -62,7 +62,7 @@ jaan-to/
   docs/                    — Reference docs (STYLE.md, create-skill.md)
 ```
 
-Also mention: `jaan-to/` will be added to `.gitignore`.
+You'll be asked whether to add `jaan-to/` to `.gitignore` (recommended: no — commit `jaan-to/` to version control).
 
 ---
 
@@ -81,6 +81,14 @@ Proceed? [y/n]
 
 **Do NOT proceed without explicit approval.**
 
+Then ask:
+
+```
+Add `jaan-to/` to .gitignore? (Recommended: No — commit jaan-to/ to version control) [y/n]
+```
+
+Record the user's answer for Step 3.5.
+
 ---
 
 # PHASE 2: Generation (Write Phase)
@@ -98,11 +106,18 @@ Note: The bootstrap script creates the `jaan-to/` directory and all subdirectori
 2. Copying seed context files (tech.md, team.md, integrations.md, etc.)
 3. Copying reference docs
 4. Initializing settings.yaml
-5. Adding `jaan-to/` to `.gitignore`
 
 Templates and learn files are loaded from the plugin at runtime (lazy loading).
 Customize templates by copying them to `jaan-to/templates/`.
 Add project lessons via `/jaan-to:learn-add`.
+
+## Step 3.5: Conditional .gitignore
+
+If the user chose **yes** to adding `jaan-to/` to `.gitignore` during the HARD STOP:
+- If `.gitignore` exists, append `jaan-to/` (skip if already present)
+- If `.gitignore` does not exist, create it with `jaan-to/`
+
+If the user chose **no**, skip this step entirely.
 
 ## Step 4: Report Result
 
@@ -132,7 +147,7 @@ Use: /jaan-to:learn-add "jaan-init" "lesson"
 - [ ] `jaan-to/` directory exists with subdirectories: outputs/, learn/, context/, templates/, config/, docs/
 - [ ] `jaan-to/config/settings.yaml` exists
 - [ ] Context seed files copied to `jaan-to/context/`
-- [ ] `.gitignore` contains `jaan-to/` entry
+- [ ] User was asked about `.gitignore` preference
 - [ ] User informed of next steps
 - [ ] User has approved final result
 


### PR DESCRIPTION
## Summary
- Removed automatic `jaan-to/` → `.gitignore` policy from `bootstrap.sh` (ran every session start)
- `jaan-init` now asks users during initialization whether to add `jaan-to/` to `.gitignore`, with recommendation: **No** (commit `jaan-to/` to version control)
- Updated `verify-install.sh` (removed gitignore check, renumbered sections), docs (`bootstrap.md`, `README.md`, `jaan-init.md`), and changelog

## Test plan
- [ ] Run `bash scripts/bootstrap.sh` on a test project — confirm no `.gitignore` modification
- [ ] Run `bash scripts/verify-install.sh` — confirm no gitignore check in output
- [ ] Read `skills/jaan-init/SKILL.md` — confirm gitignore question exists with "No" as recommended default
- [ ] Grep source tree for `gitignore.*jaan-to` — confirm only jaan-init (conditional), changelog (historical), and unrelated scaffold skills remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)