### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #188)

### DIFF
--- a/adapters/codex/skillpack/runtime/docs/extending/create-skill.md
+++ b/adapters/codex/skillpack/runtime/docs/extending/create-skill.md
@@ -1300,7 +1300,7 @@ Simplest valid skill structure:
 name: example-minimal-demo
 description: Demonstrate minimal skill structure.
 allowed-tools: Read, Write($JAAN_OUTPUTS_DIR/example/**)
-argument-hint: [topic]
+argument-hint: "[topic]"
 ---
 
 # example-minimal-demo
@@ -1400,7 +1400,7 @@ Complete skill with all v3.0.0 patterns:
 name: qa-test-matrix
 description: Generate comprehensive test matrix from feature requirements.
 allowed-tools: Read, Glob, Grep, Task, WebSearch, Write($JAAN_OUTPUTS_DIR/qa/**)
-argument-hint: [feature-name-or-prd-path]
+argument-hint: "[feature-name-or-prd-path]"
 ---
 
 # qa-test-matrix

--- a/adapters/codex/skillpack/skills/backend-api-contract/SKILL.md
+++ b/adapters/codex/skillpack/skills/backend-api-contract/SKILL.md
@@ -2,7 +2,7 @@
 name: backend-api-contract
 description: Generate OpenAPI 3.1 contracts with schemas, RFC 9457 errors, versioning, and examples. Use when defining API contracts from entities.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/backend/api-contract/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [entities-or-prd-path]
+argument-hint: "[entities-or-prd-path]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/backend-data-model/SKILL.md
+++ b/adapters/codex/skillpack/skills/backend-data-model/SKILL.md
@@ -2,7 +2,7 @@
 name: backend-data-model
 description: Generate data model docs with tables, constraints, indexes, retention, and migration notes. Use when designing database schemas from entities.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/backend/data-model/**), Write($JAAN_OUTPUTS_DIR/frontend/**), Task, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [entities-or-prd-path]
+argument-hint: "[entities-or-prd-path]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/backend-scaffold/SKILL.md
+++ b/adapters/codex/skillpack/skills/backend-scaffold/SKILL.md
@@ -2,7 +2,7 @@
 name: backend-scaffold
 description: Generate production-ready backend code with routes, data models, service layers, and validation. Use when scaffolding backend from specs.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/backend/scaffold/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [backend-api-contract, backend-task-breakdown, backend-data-model]
+argument-hint: "[backend-api-contract, backend-task-breakdown, backend-data-model]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/backend-service-implement/SKILL.md
+++ b/adapters/codex/skillpack/skills/backend-service-implement/SKILL.md
@@ -2,7 +2,7 @@
 name: backend-service-implement
 description: Generate service implementations with business logic from specs and scaffold stubs. Use when implementing backend services.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/backend/service-implement/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [backend-scaffold, backend-api-contract, backend-data-model, backend-task-breakdown]
+argument-hint: "[backend-scaffold, backend-api-contract, backend-data-model, backend-task-breakdown]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/backend-task-breakdown/SKILL.md
+++ b/adapters/codex/skillpack/skills/backend-task-breakdown/SKILL.md
@@ -2,7 +2,7 @@
 name: backend-task-breakdown
 description: Convert a PRD into structured backend development tasks with reliability patterns. Use when planning backend work from requirements.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/backend/task-breakdown/**), Task, Edit(jaan-to/config/settings.yaml)
-argument-hint: [prd-path] OR [feature-description]
+argument-hint: "[prd-path] OR [feature-description]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/data-gtm-datalayer/SKILL.md
+++ b/adapters/codex/skillpack/skills/data-gtm-datalayer/SKILL.md
@@ -2,7 +2,7 @@
 name: data-gtm-datalayer
 description: Generate production-ready GTM tracking code with dataLayer pushes and HTML attributes. Use when adding analytics tracking.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**), Edit(jaan-to/config/settings.yaml)
-argument-hint: [prd-path | tracking-description | (interactive)]
+argument-hint: "[prd-path | tracking-description | (interactive)]"
 disable-model-invocation: true
 license: PROPRIETARY
 ---

--- a/adapters/codex/skillpack/skills/dev-docs-fetch/SKILL.md
+++ b/adapters/codex/skillpack/skills/dev-docs-fetch/SKILL.md
@@ -2,7 +2,7 @@
 name: dev-docs-fetch
 description: Fetch and cache library docs via Context7 MCP with auto-detect. Use when fetching technical documentation.
 allowed-tools: Read, Glob, Grep, Bash(find:*), Bash(stat:*), Bash(mkdir:*), Bash(date:*), Bash(ls:*), mcp__context7__resolve-library-id, mcp__context7__get-library-docs, Write($JAAN_OUTPUTS_DIR/dev/docs/context7/**), AskUserQuestion
-argument-hint: [library-names...]
+argument-hint: "[library-names...]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/dev-output-integrate/SKILL.md
+++ b/adapters/codex/skillpack/skills/dev-output-integrate/SKILL.md
@@ -2,7 +2,7 @@
 name: dev-output-integrate
 description: Copy generated jaan-to outputs into project locations with entry point wiring and validation. Use when integrating generated code.
 allowed-tools: Read, Glob, Grep, Write(src/**), Write(apps/**), Write(prisma/**), Write(test/**), Write(tests/**), Write(.github/**), Write(docker/**), Write(deploy/**), Write(package.json), Write(tsconfig.json), Write(vitest.config.*), Write(playwright.config.*), Write(next.config.*), Write(tailwind.config.*), Write(.gitignore), Write(.dockerignore), Write(Dockerfile*), Write(docker-compose*), Write(turbo.json), Write($JAAN_OUTPUTS_DIR/dev/output-integrate/**), Write($JAAN_OUTPUTS_DIR/.last-integration-manifest), Bash(pnpm install:*), Bash(pnpm run:*), Bash(npm install:*), Bash(npm run:*), Bash(npx tsc:*), Bash(ls:*), Bash(mkdir:*), Bash(npx msw:*), Write(orval.config.ts), Edit(orval.config.ts), Write(.storybook/**), Edit(.storybook/**), Task, AskUserQuestion, Edit(src/**), Edit(apps/**), Edit(package.json), Edit(tsconfig.json), Edit(next.config.*), Edit(turbo.json)
-argument-hint: [output-path...] or (interactive scan)
+argument-hint: "[output-path...] or (interactive scan)"
 disable-model-invocation: true
 license: PROPRIETARY
 ---

--- a/adapters/codex/skillpack/skills/dev-project-assemble/SKILL.md
+++ b/adapters/codex/skillpack/skills/dev-project-assemble/SKILL.md
@@ -2,7 +2,7 @@
 name: dev-project-assemble
 description: Wire scaffold outputs into runnable project structure with configs and entry points. Use when assembling project from scaffolds.
 allowed-tools: Read, Glob, Grep, Write(src/**), Write(prisma/**), Write(package.json), Write(tsconfig.json), Write(next.config.*), Write(tailwind.config.*), Write(.env.example), Write(.gitignore), Write($JAAN_OUTPUTS_DIR/dev/project-assemble/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [backend-scaffold, frontend-scaffold] [backend-api-contract] [target-dir]
+argument-hint: "[backend-scaffold, frontend-scaffold] [backend-api-contract] [target-dir]"
 disable-model-invocation: true
 license: PROPRIETARY
 ---

--- a/adapters/codex/skillpack/skills/dev-verify/SKILL.md
+++ b/adapters/codex/skillpack/skills/dev-verify/SKILL.md
@@ -2,7 +2,7 @@
 name: dev-verify
 description: Validate integrated build pipeline and running services with health checks and smoke tests. Use when verifying project builds.
 allowed-tools: Read, Glob, Grep, Bash(pnpm:*), Bash(npm:*), Bash(yarn:*), Bash(composer:*), Bash(go:*), Bash(npx tsc:*), Bash(npx storybook:*), Bash(turbo:*), Bash(curl:*), Bash(docker compose:*), Bash(docker:*), Bash(lsof:*), Bash(nc:*), Bash(ss:*), Bash(ls:*), Bash(mkdir:*), Write($JAAN_OUTPUTS_DIR/dev/verify/**), Task, AskUserQuestion, Edit(src/**), Edit(apps/**), Edit(package.json), Edit(tsconfig.json), Edit(composer.json), Edit(jaan-to/config/settings.yaml)
-argument-hint: [--build-only | --runtime-only] [--skip-smoke] [--skip-fix] [--port PORT]
+argument-hint: "[--build-only | --runtime-only] [--skip-smoke] [--skip-fix] [--port PORT]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/devops-deploy-activate/SKILL.md
+++ b/adapters/codex/skillpack/skills/devops-deploy-activate/SKILL.md
@@ -2,7 +2,7 @@
 name: devops-deploy-activate
 description: Activate deployment pipeline with secrets, platform provisioning, and supply chain hardening. Use when deploying to production.
 allowed-tools: Read, Glob, Grep, Bash(gh secret:*), Bash(gh variable:*), Bash(gh workflow:*), Bash(gh api:*), Bash(gh run:*), Bash(gh auth:*), Bash(railway init:*), Bash(railway link:*), Bash(railway status:*), Bash(railway variables:*), Bash(vercel deploy:*), Bash(vercel env:*), Bash(vercel link:*), Bash(vercel inspect:*), Bash(fly launch:*), Bash(fly deploy:*), Bash(fly secrets:*), Bash(fly status:*), Bash(turbo run:*), Write(.github/**), Write($JAAN_OUTPUTS_DIR/devops/deploy-activate/**), Task, WebSearch, AskUserQuestion, Edit(.github/**)
-argument-hint: [infra-scaffold-output] or (interactive)
+argument-hint: "[infra-scaffold-output] or (interactive)"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/frontend-design/SKILL.md
+++ b/adapters/codex/skillpack/skills/frontend-design/SKILL.md
@@ -2,7 +2,7 @@
 name: frontend-design
 description: Create distinctive, production-grade frontend interfaces with bold design choices and working code. Use when designing UI components.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/frontend/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [component-description-or-requirements] [--contract backend-api-contract-path]
+argument-hint: "[component-description-or-requirements] [--contract backend-api-contract-path]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/frontend-scaffold/SKILL.md
+++ b/adapters/codex/skillpack/skills/frontend-scaffold/SKILL.md
@@ -2,7 +2,7 @@
 name: frontend-scaffold
 description: Convert designs to React/Next.js components with TailwindCSS, TypeScript, and typed API hooks. Use when scaffolding frontend from designs.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/frontend/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [frontend-design, frontend-task-breakdown, backend-api-contract]
+argument-hint: "[frontend-design, frontend-task-breakdown, backend-api-contract]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/frontend-task-breakdown/SKILL.md
+++ b/adapters/codex/skillpack/skills/frontend-task-breakdown/SKILL.md
@@ -2,7 +2,7 @@
 name: frontend-task-breakdown
 description: Generate frontend task breakdowns from UX handoffs with component inventory and state matrices. Use when planning frontend work.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/frontend/task-breakdown/**), Bash(cp:*), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [ux-handoff-description-or-figma-link] [--contract backend-api-contract-path]
+argument-hint: "[ux-handoff-description-or-figma-link] [--contract backend-api-contract-path]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/pm-prd-write/SKILL.md
+++ b/adapters/codex/skillpack/skills/pm-prd-write/SKILL.md
@@ -2,7 +2,7 @@
 name: pm-prd-write
 description: Generate a Product Requirements Document from an initiative description. Use when defining product scope or feature requirements.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**), Bash(cp:*), Edit(jaan-to/config/settings.yaml)
-argument-hint: [initiative-description]
+argument-hint: "[initiative-description]"
 hooks:
   PreToolUse:
     - matcher: "Write"

--- a/adapters/codex/skillpack/skills/pm-roadmap-add/SKILL.md
+++ b/adapters/codex/skillpack/skills/pm-roadmap-add/SKILL.md
@@ -2,7 +2,7 @@
 name: pm-roadmap-add
 description: Add prioritized items to a project roadmap with codebase review and duplication check. Use when planning product direction.
 allowed-tools: Read, Glob, Grep, Write(ROADMAP.md), Write($JAAN_OUTPUTS_DIR/pm/roadmap/**), Edit(ROADMAP.md), Edit($JAAN_OUTPUTS_DIR/pm/roadmap/**), Bash(cp:*), Bash(git add:*), Bash(git commit:*), Bash(git remote get-url:*), Edit(jaan-to/config/settings.yaml)
-argument-hint: [item-description]
+argument-hint: "[item-description]"
 hooks:
   PreToolUse:
     - matcher: "Write"

--- a/adapters/codex/skillpack/skills/pm-skill-discover/SKILL.md
+++ b/adapters/codex/skillpack/skills/pm-skill-discover/SKILL.md
@@ -2,7 +2,7 @@
 name: pm-skill-discover
 description: Detect repeated workflow patterns from AI sessions and suggest skills to automate them. Use when optimizing workflows.
 allowed-tools: Read, Glob, Grep, Bash(ls:*), Bash(wc:*), Bash(jq:*), Bash(git log:*), Write($JAAN_OUTPUTS_DIR/pm/skill-discover/**), Edit(jaan-to/config/settings.yaml), Task
-argument-hint: [--days=N] [--min-frequency=N] [--max-suggestions=N]
+argument-hint: "[--days=N] [--min-frequency=N] [--max-suggestions=N]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/pm-story-write/SKILL.md
+++ b/adapters/codex/skillpack/skills/pm-story-write/SKILL.md
@@ -2,7 +2,7 @@
 name: pm-story-write
 description: Generate user stories with Given/When/Then acceptance criteria following INVEST principles. Use when writing user stories from PRDs.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**), Bash(cp:*), Task, Edit(jaan-to/config/settings.yaml)
-argument-hint: [feature] [persona] [goal] OR [epic-id]
+argument-hint: "[feature] [persona] [goal] OR [epic-id]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/qa-test-cases/SKILL.md
+++ b/adapters/codex/skillpack/skills/qa-test-cases/SKILL.md
@@ -2,7 +2,7 @@
 name: qa-test-cases
 description: Generate BDD/Gherkin test cases from acceptance criteria with ISTQB techniques. Use when writing test specs.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/qa/**), Task, WebSearch, Edit(jaan-to/config/settings.yaml)
-argument-hint: [acceptance-criteria | prd-path | jira-id | (interactive)] [--contract backend-api-contract-path]
+argument-hint: "[acceptance-criteria | prd-path | jira-id | (interactive)] [--contract backend-api-contract-path]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/qa-test-generate/SKILL.md
+++ b/adapters/codex/skillpack/skills/qa-test-generate/SKILL.md
@@ -2,7 +2,7 @@
 name: qa-test-generate
 description: Generate runnable test files from BDD test cases and scaffold code. Use when creating test implementations.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/qa/test-generate/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [qa-test-cases, backend-scaffold | frontend-scaffold]
+argument-hint: "[qa-test-cases, backend-scaffold | frontend-scaffold]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/qa-test-run/SKILL.md
+++ b/adapters/codex/skillpack/skills/qa-test-run/SKILL.md
@@ -2,7 +2,7 @@
 name: qa-test-run
 description: Execute tests, diagnose failures, auto-fix and generate coverage reports. Use when running test suites.
 allowed-tools: Read, Glob, Grep, Bash(npm test:*), Bash(npm run test:*), Bash(npm run lint:*), Bash(npx vitest:*), Bash(npx jest:*), Bash(npx playwright:*), Bash(npx tsc:*), Bash(npx prisma generate:*), Bash(pnpm test:*), Bash(pnpm run test:*), Bash(pnpm run lint:*), Bash(pnpm exec:*), Bash(yarn test:*), Bash(yarn run test:*), Bash(composer test:*), Bash(composer dump-autoload:*), Bash(go test:*), Bash(go generate:*), Bash(go mod tidy:*), Bash(go tool cover:*), Bash(php artisan test:*), Bash(php artisan migrate:*), Bash(vendor/bin/phpunit:*), Bash(vendor/bin/pest:*), Write($JAAN_OUTPUTS_DIR/qa/test-run/**), Task, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [qa-test-generate-output | test-directory] [--unit | --integration | --e2e | --mutation | --contract | --all]
+argument-hint: "[qa-test-generate-output | test-directory] [--unit | --integration | --e2e | --mutation | --contract | --all]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/skill-create/SKILL.md
+++ b/adapters/codex/skillpack/skills/skill-create/SKILL.md
@@ -2,7 +2,7 @@
 name: skill-create
 description: Guide users through creating new jaan-to skills step-by-step. Use when building a new plugin skill.
 allowed-tools: Read, Glob, Grep, Task, WebSearch, Write(skills/**), Write(docs/**), Write($JAAN_OUTPUTS_DIR/**), Edit($JAAN_TEMPLATES_DIR/**), Edit($JAAN_LEARN_DIR/**), Edit(jaan-to/config/settings.yaml), Bash(bash scripts/prepare-skill-pr.sh*), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(gh pr create:*)
-argument-hint: [optional-skill-idea]
+argument-hint: "[optional-skill-idea]"
 disable-model-invocation: true
 license: PROPRIETARY
 ---

--- a/adapters/codex/skillpack/skills/skill-update/SKILL.md
+++ b/adapters/codex/skillpack/skills/skill-update/SKILL.md
@@ -2,7 +2,7 @@
 name: skill-update
 description: Update an existing jaan-to skill following standards. Use when modifying or improving existing skills.
 allowed-tools: Read, Glob, Grep, Task, WebSearch, Write(skills/**), Write(docs/**), Write($JAAN_OUTPUTS_DIR/**), Edit(skills/**), Edit(docs/**), Bash(bash scripts/prepare-skill-pr.sh*), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(gh pr create:*)
-argument-hint: [skill-name]
+argument-hint: "[skill-name]"
 disable-model-invocation: true
 license: PROPRIETARY
 ---

--- a/adapters/codex/skillpack/skills/ux-flowchart-generate/SKILL.md
+++ b/adapters/codex/skillpack/skills/ux-flowchart-generate/SKILL.md
@@ -2,7 +2,7 @@
 name: ux-flowchart-generate
 description: Generate GitHub-renderable Mermaid flowcharts from PRD/docs/codebase with evidence maps. Use when creating user flow diagrams.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/**), Bash(cp:*), Task, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [source_type] [paths...] [goal] [scope?]
+argument-hint: "[source_type] [paths...] [goal] [scope?]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/ux-heatmap-analyze/SKILL.md
+++ b/adapters/codex/skillpack/skills/ux-heatmap-analyze/SKILL.md
@@ -2,7 +2,7 @@
 name: ux-heatmap-analyze
 description: Analyze heatmap data from CSV exports and screenshots to generate prioritized UX reports. Use when interpreting heatmap data.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/**), Bash(cp:*), Edit(jaan-to/config/settings.yaml)
-argument-hint: [csv-path] [screenshot-path] [html-path?] [problem?]
+argument-hint: "[csv-path] [screenshot-path] [html-path?] [problem?]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/ux-microcopy-write/SKILL.md
+++ b/adapters/codex/skillpack/skills/ux-microcopy-write/SKILL.md
@@ -2,7 +2,7 @@
 name: ux-microcopy-write
 description: Generate multi-language microcopy packs for UI components with cultural adaptation. Use when writing UI text and translations.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/**), Write($JAAN_CONTEXT_DIR/localization.md), Write($JAAN_CONTEXT_DIR/tone-of-voice.md), WebSearch, Task, AskUserQuestion, Bash(source:*), Bash(mkdir:*), Edit(jaan-to/config/settings.yaml)
-argument-hint: [initiative-or-feature-description]
+argument-hint: "[initiative-or-feature-description]"
 license: PROPRIETARY
 ---
 

--- a/adapters/codex/skillpack/skills/ux-research-synthesize/SKILL.md
+++ b/adapters/codex/skillpack/skills/ux-research-synthesize/SKILL.md
@@ -2,7 +2,7 @@
 name: ux-research-synthesize
 description: Synthesize UX research findings into themed insights and prioritized recommendations. Use when analyzing research data.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/research/**), Task, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [study-name] [data-sources?]
+argument-hint: "[study-name] [data-sources?]"
 license: PROPRIETARY
 ---
 

--- a/docs/extending/create-skill.md
+++ b/docs/extending/create-skill.md
@@ -1300,7 +1300,7 @@ Simplest valid skill structure:
 name: example-minimal-demo
 description: Demonstrate minimal skill structure.
 allowed-tools: Read, Write($JAAN_OUTPUTS_DIR/example/**)
-argument-hint: [topic]
+argument-hint: "[topic]"
 ---
 
 # example-minimal-demo
@@ -1400,7 +1400,7 @@ Complete skill with all v3.0.0 patterns:
 name: qa-test-matrix
 description: Generate comprehensive test matrix from feature requirements.
 allowed-tools: Read, Glob, Grep, Task, WebSearch, Write($JAAN_OUTPUTS_DIR/qa/**)
-argument-hint: [feature-name-or-prd-path]
+argument-hint: "[feature-name-or-prd-path]"
 ---
 
 # qa-test-matrix

--- a/docs/research/22-data-microsoft-clarity.md
+++ b/docs/research/22-data-microsoft-clarity.md
@@ -270,7 +270,7 @@ description: |
   Analyze Microsoft Clarity heatmap and session data for UX insights.
   Auto-triggers on: clarity analysis, heatmap review, session patterns
 allowed-tools: Read, Glob, Grep, Write(jaan-to/**), Bash(python:*)
-argument-hint: [csv-path-or-session-url]
+argument-hint: "[csv-path-or-session-url]"
 ---
 ```
 

--- a/docs/research/23-ai-workflow-claude-code-plugin-standards.md
+++ b/docs/research/23-ai-workflow-claude-code-plugin-standards.md
@@ -252,7 +252,7 @@ Enterprise (wins) > CLI flags > Project local > Project shared > User
 ```yaml
 ---
 allowed-tools: Bash(npm:*), mcp__jira__*
-argument-hint: [required] [--optional]
+argument-hint: "[required] [--optional]"
 description: One-line for autocomplete
 model: claude-sonnet-4-20250514  # Optional override
 ---

--- a/docs/research/25-ai-workflow-enterprise-plugin-packs.md
+++ b/docs/research/25-ai-workflow-enterprise-plugin-packs.md
@@ -183,7 +183,7 @@ Commands live in `.claude/commands/` as markdown files:
 ```markdown
 ---
 allowed-tools: Bash(npm run:*), Bash(git:*)
-argument-hint: [ticket-id] [--dry-run]
+argument-hint: "[ticket-id] [--dry-run]"
 description: Create PR from Jira ticket with linked requirements
 model: claude-sonnet-4-20250514
 ---
@@ -488,7 +488,7 @@ For human-in-the-loop confirmation via Telegram:
 ```markdown
 ---
 allowed-tools: mcp__figma__*, mcp__jira__*, mcp__api-spec__*, Bash(git:*)
-argument-hint: [figma-url] [--create-tickets]
+argument-hint: "[figma-url] [--create-tickets]"
 description: Create PRD from Figma design with API context, optionally create Jira tickets
 ---
 

--- a/docs/research/34-ai-workflow-claude-code-skills-official.md
+++ b/docs/research/34-ai-workflow-claude-code-skills-official.md
@@ -46,7 +46,7 @@ my-skill/
 ---
 name: my-skill
 description: What this skill does
-argument-hint: [issue-number]
+argument-hint: "[issue-number]"
 disable-model-invocation: true
 user-invocable: false
 allowed-tools: Read, Grep, Glob

--- a/docs/roadmap/plans/dev-app-develop.md
+++ b/docs/roadmap/plans/dev-app-develop.md
@@ -30,7 +30,7 @@ This is the **first "action skill"** in jaan-to — it writes source code to the
 name: dev-app-develop
 description: Full-lifecycle app development from task selection through implementation, testing, and deployment.
 allowed-tools: Read, Glob, Grep, Task, WebSearch, Write, Edit, AskUserQuestion, Bash(git:*), Bash(gh:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*), Bash(pip:*), Bash(python:*), Bash(pytest:*), Bash(go:*), Bash(cargo:*), Bash(composer:*), Bash(php:*), Bash(make:*), Bash(docker:*), Bash(curl:*), Bash(semgrep:*), Bash(trivy:*)
-argument-hint: [task-id or task-description]
+argument-hint: "[task-id or task-description]"
 ---
 ```
 

--- a/docs/roadmap/plans/dev-scaffold-skills.md
+++ b/docs/roadmap/plans/dev-scaffold-skills.md
@@ -65,7 +65,7 @@ These issues were identified by deep verification against plugin standards and r
 name: backend-scaffold
 description: Generate production-ready backend code from specs: routes, data model, service layer, validation.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [backend-api-contract, backend-task-breakdown, backend-data-model]
+argument-hint: "[backend-api-contract, backend-task-breakdown, backend-data-model]"
 ```
 
 ### Context Files
@@ -332,7 +332,7 @@ The skill reads tech.md `#current-stack` to determine which stack to generate:
 name: frontend-scaffold
 description: Convert designs to React/Next.js components with TailwindCSS, TypeScript, and typed API client hooks.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/dev/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [frontend-design, frontend-task-breakdown, backend-api-contract]
+argument-hint: "[frontend-design, frontend-task-breakdown, backend-api-contract]"
 ```
 
 ### Context Files

--- a/docs/roadmap/plans/ux-flowchart-generate.md
+++ b/docs/roadmap/plans/ux-flowchart-generate.md
@@ -20,7 +20,7 @@ The `ux-flowchart-generate` skill generates GitHub-renderable Mermaid flowcharts
 name: ux-flowchart-generate
 description: Generate GitHub-renderable Mermaid flowcharts from PRD/docs/codebase with evidence maps and confidence scoring.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/**), Task, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [source_type] [paths...] [goal] [scope?]
+argument-hint: "[source_type] [paths...] [goal] [scope?]"
 ---
 ```
 

--- a/skills/backend-api-contract/SKILL.md
+++ b/skills/backend-api-contract/SKILL.md
@@ -2,7 +2,7 @@
 name: backend-api-contract
 description: Generate OpenAPI 3.1 contracts with schemas, RFC 9457 errors, versioning, and examples. Use when defining API contracts from entities.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/backend/api-contract/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [entities-or-prd-path]
+argument-hint: "[entities-or-prd-path]"
 license: PROPRIETARY
 ---
 

--- a/skills/backend-data-model/SKILL.md
+++ b/skills/backend-data-model/SKILL.md
@@ -2,7 +2,7 @@
 name: backend-data-model
 description: Generate data model docs with tables, constraints, indexes, retention, and migration notes. Use when designing database schemas from entities.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/backend/data-model/**), Write($JAAN_OUTPUTS_DIR/frontend/**), Task, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [entities-or-prd-path]
+argument-hint: "[entities-or-prd-path]"
 license: PROPRIETARY
 ---
 

--- a/skills/backend-scaffold/SKILL.md
+++ b/skills/backend-scaffold/SKILL.md
@@ -2,7 +2,7 @@
 name: backend-scaffold
 description: Generate production-ready backend code with routes, data models, service layers, and validation. Use when scaffolding backend from specs.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/backend/scaffold/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [backend-api-contract, backend-task-breakdown, backend-data-model]
+argument-hint: "[backend-api-contract, backend-task-breakdown, backend-data-model]"
 license: PROPRIETARY
 ---
 

--- a/skills/backend-service-implement/SKILL.md
+++ b/skills/backend-service-implement/SKILL.md
@@ -2,7 +2,7 @@
 name: backend-service-implement
 description: Generate service implementations with business logic from specs and scaffold stubs. Use when implementing backend services.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/backend/service-implement/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [backend-scaffold, backend-api-contract, backend-data-model, backend-task-breakdown]
+argument-hint: "[backend-scaffold, backend-api-contract, backend-data-model, backend-task-breakdown]"
 license: PROPRIETARY
 ---
 

--- a/skills/backend-task-breakdown/SKILL.md
+++ b/skills/backend-task-breakdown/SKILL.md
@@ -2,7 +2,7 @@
 name: backend-task-breakdown
 description: Convert a PRD into structured backend development tasks with reliability patterns. Use when planning backend work from requirements.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/backend/task-breakdown/**), Task, Edit(jaan-to/config/settings.yaml)
-argument-hint: [prd-path] OR [feature-description]
+argument-hint: "[prd-path] OR [feature-description]"
 license: PROPRIETARY
 ---
 

--- a/skills/data-gtm-datalayer/SKILL.md
+++ b/skills/data-gtm-datalayer/SKILL.md
@@ -2,7 +2,7 @@
 name: data-gtm-datalayer
 description: Generate production-ready GTM tracking code with dataLayer pushes and HTML attributes. Use when adding analytics tracking.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**), Edit(jaan-to/config/settings.yaml)
-argument-hint: [prd-path | tracking-description | (interactive)]
+argument-hint: "[prd-path | tracking-description | (interactive)]"
 disable-model-invocation: true
 license: PROPRIETARY
 ---

--- a/skills/dev-docs-fetch/SKILL.md
+++ b/skills/dev-docs-fetch/SKILL.md
@@ -2,7 +2,7 @@
 name: dev-docs-fetch
 description: Fetch and cache library docs via Context7 MCP with auto-detect. Use when fetching technical documentation.
 allowed-tools: Read, Glob, Grep, Bash(find:*), Bash(stat:*), Bash(mkdir:*), Bash(date:*), Bash(ls:*), mcp__context7__resolve-library-id, mcp__context7__get-library-docs, Write($JAAN_OUTPUTS_DIR/dev/docs/context7/**), AskUserQuestion
-argument-hint: [library-names...]
+argument-hint: "[library-names...]"
 license: PROPRIETARY
 ---
 

--- a/skills/dev-output-integrate/SKILL.md
+++ b/skills/dev-output-integrate/SKILL.md
@@ -2,7 +2,7 @@
 name: dev-output-integrate
 description: Copy generated jaan-to outputs into project locations with entry point wiring and validation. Use when integrating generated code.
 allowed-tools: Read, Glob, Grep, Write(src/**), Write(apps/**), Write(prisma/**), Write(test/**), Write(tests/**), Write(.github/**), Write(docker/**), Write(deploy/**), Write(package.json), Write(tsconfig.json), Write(vitest.config.*), Write(playwright.config.*), Write(next.config.*), Write(tailwind.config.*), Write(.gitignore), Write(.dockerignore), Write(Dockerfile*), Write(docker-compose*), Write(turbo.json), Write($JAAN_OUTPUTS_DIR/dev/output-integrate/**), Write($JAAN_OUTPUTS_DIR/.last-integration-manifest), Bash(pnpm install:*), Bash(pnpm run:*), Bash(npm install:*), Bash(npm run:*), Bash(npx tsc:*), Bash(ls:*), Bash(mkdir:*), Bash(npx msw:*), Write(orval.config.ts), Edit(orval.config.ts), Write(.storybook/**), Edit(.storybook/**), Task, AskUserQuestion, Edit(src/**), Edit(apps/**), Edit(package.json), Edit(tsconfig.json), Edit(next.config.*), Edit(turbo.json)
-argument-hint: [output-path...] or (interactive scan)
+argument-hint: "[output-path...] or (interactive scan)"
 disable-model-invocation: true
 license: PROPRIETARY
 ---

--- a/skills/dev-project-assemble/SKILL.md
+++ b/skills/dev-project-assemble/SKILL.md
@@ -2,7 +2,7 @@
 name: dev-project-assemble
 description: Wire scaffold outputs into runnable project structure with configs and entry points. Use when assembling project from scaffolds.
 allowed-tools: Read, Glob, Grep, Write(src/**), Write(prisma/**), Write(package.json), Write(tsconfig.json), Write(next.config.*), Write(tailwind.config.*), Write(.env.example), Write(.gitignore), Write($JAAN_OUTPUTS_DIR/dev/project-assemble/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [backend-scaffold, frontend-scaffold] [backend-api-contract] [target-dir]
+argument-hint: "[backend-scaffold, frontend-scaffold] [backend-api-contract] [target-dir]"
 disable-model-invocation: true
 license: PROPRIETARY
 ---

--- a/skills/dev-verify/SKILL.md
+++ b/skills/dev-verify/SKILL.md
@@ -2,7 +2,7 @@
 name: dev-verify
 description: Validate integrated build pipeline and running services with health checks and smoke tests. Use when verifying project builds.
 allowed-tools: Read, Glob, Grep, Bash(pnpm:*), Bash(npm:*), Bash(yarn:*), Bash(composer:*), Bash(go:*), Bash(npx tsc:*), Bash(npx storybook:*), Bash(turbo:*), Bash(curl:*), Bash(docker compose:*), Bash(docker:*), Bash(lsof:*), Bash(nc:*), Bash(ss:*), Bash(ls:*), Bash(mkdir:*), Write($JAAN_OUTPUTS_DIR/dev/verify/**), Task, AskUserQuestion, Edit(src/**), Edit(apps/**), Edit(package.json), Edit(tsconfig.json), Edit(composer.json), Edit(jaan-to/config/settings.yaml)
-argument-hint: [--build-only | --runtime-only] [--skip-smoke] [--skip-fix] [--port PORT]
+argument-hint: "[--build-only | --runtime-only] [--skip-smoke] [--skip-fix] [--port PORT]"
 license: PROPRIETARY
 ---
 

--- a/skills/devops-deploy-activate/SKILL.md
+++ b/skills/devops-deploy-activate/SKILL.md
@@ -2,7 +2,7 @@
 name: devops-deploy-activate
 description: Activate deployment pipeline with secrets, platform provisioning, and supply chain hardening. Use when deploying to production.
 allowed-tools: Read, Glob, Grep, Bash(gh secret:*), Bash(gh variable:*), Bash(gh workflow:*), Bash(gh api:*), Bash(gh run:*), Bash(gh auth:*), Bash(railway init:*), Bash(railway link:*), Bash(railway status:*), Bash(railway variables:*), Bash(vercel deploy:*), Bash(vercel env:*), Bash(vercel link:*), Bash(vercel inspect:*), Bash(fly launch:*), Bash(fly deploy:*), Bash(fly secrets:*), Bash(fly status:*), Bash(turbo run:*), Write(.github/**), Write($JAAN_OUTPUTS_DIR/devops/deploy-activate/**), Task, WebSearch, AskUserQuestion, Edit(.github/**)
-argument-hint: [infra-scaffold-output] or (interactive)
+argument-hint: "[infra-scaffold-output] or (interactive)"
 license: PROPRIETARY
 ---
 

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -2,7 +2,7 @@
 name: frontend-design
 description: Create distinctive, production-grade frontend interfaces with bold design choices and working code. Use when designing UI components.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/frontend/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [component-description-or-requirements] [--contract backend-api-contract-path]
+argument-hint: "[component-description-or-requirements] [--contract backend-api-contract-path]"
 license: PROPRIETARY
 ---
 

--- a/skills/frontend-scaffold/SKILL.md
+++ b/skills/frontend-scaffold/SKILL.md
@@ -2,7 +2,7 @@
 name: frontend-scaffold
 description: Convert designs to React/Next.js components with TailwindCSS, TypeScript, and typed API hooks. Use when scaffolding frontend from designs.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/frontend/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [frontend-design, frontend-task-breakdown, backend-api-contract]
+argument-hint: "[frontend-design, frontend-task-breakdown, backend-api-contract]"
 license: PROPRIETARY
 ---
 

--- a/skills/frontend-task-breakdown/SKILL.md
+++ b/skills/frontend-task-breakdown/SKILL.md
@@ -2,7 +2,7 @@
 name: frontend-task-breakdown
 description: Generate frontend task breakdowns from UX handoffs with component inventory and state matrices. Use when planning frontend work.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/frontend/task-breakdown/**), Bash(cp:*), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [ux-handoff-description-or-figma-link] [--contract backend-api-contract-path]
+argument-hint: "[ux-handoff-description-or-figma-link] [--contract backend-api-contract-path]"
 license: PROPRIETARY
 ---
 

--- a/skills/pm-prd-write/SKILL.md
+++ b/skills/pm-prd-write/SKILL.md
@@ -2,7 +2,7 @@
 name: pm-prd-write
 description: Generate a Product Requirements Document from an initiative description. Use when defining product scope or feature requirements.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**), Bash(cp:*), Edit(jaan-to/config/settings.yaml)
-argument-hint: [initiative-description]
+argument-hint: "[initiative-description]"
 hooks:
   PreToolUse:
     - matcher: "Write"

--- a/skills/pm-roadmap-add/SKILL.md
+++ b/skills/pm-roadmap-add/SKILL.md
@@ -2,7 +2,7 @@
 name: pm-roadmap-add
 description: Add prioritized items to a project roadmap with codebase review and duplication check. Use when planning product direction.
 allowed-tools: Read, Glob, Grep, Write(ROADMAP.md), Write($JAAN_OUTPUTS_DIR/pm/roadmap/**), Edit(ROADMAP.md), Edit($JAAN_OUTPUTS_DIR/pm/roadmap/**), Bash(cp:*), Bash(git add:*), Bash(git commit:*), Bash(git remote get-url:*), Edit(jaan-to/config/settings.yaml)
-argument-hint: [item-description]
+argument-hint: "[item-description]"
 hooks:
   PreToolUse:
     - matcher: "Write"

--- a/skills/pm-skill-discover/SKILL.md
+++ b/skills/pm-skill-discover/SKILL.md
@@ -2,7 +2,7 @@
 name: pm-skill-discover
 description: Detect repeated workflow patterns from AI sessions and suggest skills to automate them. Use when optimizing workflows.
 allowed-tools: Read, Glob, Grep, Bash(ls:*), Bash(wc:*), Bash(jq:*), Bash(git log:*), Write($JAAN_OUTPUTS_DIR/pm/skill-discover/**), Edit(jaan-to/config/settings.yaml), Task
-argument-hint: [--days=N] [--min-frequency=N] [--max-suggestions=N]
+argument-hint: "[--days=N] [--min-frequency=N] [--max-suggestions=N]"
 license: PROPRIETARY
 ---
 

--- a/skills/pm-story-write/SKILL.md
+++ b/skills/pm-story-write/SKILL.md
@@ -2,7 +2,7 @@
 name: pm-story-write
 description: Generate user stories with Given/When/Then acceptance criteria following INVEST principles. Use when writing user stories from PRDs.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/**), Bash(cp:*), Task, Edit(jaan-to/config/settings.yaml)
-argument-hint: [feature] [persona] [goal] OR [epic-id]
+argument-hint: "[feature] [persona] [goal] OR [epic-id]"
 license: PROPRIETARY
 ---
 

--- a/skills/qa-test-cases/SKILL.md
+++ b/skills/qa-test-cases/SKILL.md
@@ -2,7 +2,7 @@
 name: qa-test-cases
 description: Generate BDD/Gherkin test cases from acceptance criteria with ISTQB techniques. Use when writing test specs.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/qa/**), Task, WebSearch, Edit(jaan-to/config/settings.yaml)
-argument-hint: [acceptance-criteria | prd-path | jira-id | (interactive)] [--contract backend-api-contract-path]
+argument-hint: "[acceptance-criteria | prd-path | jira-id | (interactive)] [--contract backend-api-contract-path]"
 license: PROPRIETARY
 ---
 

--- a/skills/qa-test-generate/SKILL.md
+++ b/skills/qa-test-generate/SKILL.md
@@ -2,7 +2,7 @@
 name: qa-test-generate
 description: Generate runnable test files from BDD test cases and scaffold code. Use when creating test implementations.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/qa/test-generate/**), Task, WebSearch, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [qa-test-cases, backend-scaffold | frontend-scaffold]
+argument-hint: "[qa-test-cases, backend-scaffold | frontend-scaffold]"
 license: PROPRIETARY
 ---
 

--- a/skills/qa-test-run/SKILL.md
+++ b/skills/qa-test-run/SKILL.md
@@ -2,7 +2,7 @@
 name: qa-test-run
 description: Execute tests, diagnose failures, auto-fix and generate coverage reports. Use when running test suites.
 allowed-tools: Read, Glob, Grep, Bash(npm test:*), Bash(npm run test:*), Bash(npm run lint:*), Bash(npx vitest:*), Bash(npx jest:*), Bash(npx playwright:*), Bash(npx tsc:*), Bash(npx prisma generate:*), Bash(pnpm test:*), Bash(pnpm run test:*), Bash(pnpm run lint:*), Bash(pnpm exec:*), Bash(yarn test:*), Bash(yarn run test:*), Bash(composer test:*), Bash(composer dump-autoload:*), Bash(go test:*), Bash(go generate:*), Bash(go mod tidy:*), Bash(go tool cover:*), Bash(php artisan test:*), Bash(php artisan migrate:*), Bash(vendor/bin/phpunit:*), Bash(vendor/bin/pest:*), Write($JAAN_OUTPUTS_DIR/qa/test-run/**), Task, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [qa-test-generate-output | test-directory] [--unit | --integration | --e2e | --mutation | --contract | --all]
+argument-hint: "[qa-test-generate-output | test-directory] [--unit | --integration | --e2e | --mutation | --contract | --all]"
 license: PROPRIETARY
 ---
 

--- a/skills/skill-create/SKILL.md
+++ b/skills/skill-create/SKILL.md
@@ -2,7 +2,7 @@
 name: skill-create
 description: Guide users through creating new jaan-to skills step-by-step. Use when building a new plugin skill.
 allowed-tools: Read, Glob, Grep, Task, WebSearch, Write(skills/**), Write(docs/**), Write($JAAN_OUTPUTS_DIR/**), Edit($JAAN_TEMPLATES_DIR/**), Edit($JAAN_LEARN_DIR/**), Edit(jaan-to/config/settings.yaml), Bash(bash scripts/prepare-skill-pr.sh*), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(gh pr create:*)
-argument-hint: [optional-skill-idea]
+argument-hint: "[optional-skill-idea]"
 disable-model-invocation: true
 license: PROPRIETARY
 ---

--- a/skills/skill-update/SKILL.md
+++ b/skills/skill-update/SKILL.md
@@ -2,7 +2,7 @@
 name: skill-update
 description: Update an existing jaan-to skill following standards. Use when modifying or improving existing skills.
 allowed-tools: Read, Glob, Grep, Task, WebSearch, Write(skills/**), Write(docs/**), Write($JAAN_OUTPUTS_DIR/**), Edit(skills/**), Edit(docs/**), Bash(bash scripts/prepare-skill-pr.sh*), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(gh pr create:*)
-argument-hint: [skill-name]
+argument-hint: "[skill-name]"
 disable-model-invocation: true
 license: PROPRIETARY
 ---

--- a/skills/ux-flowchart-generate/SKILL.md
+++ b/skills/ux-flowchart-generate/SKILL.md
@@ -2,7 +2,7 @@
 name: ux-flowchart-generate
 description: Generate GitHub-renderable Mermaid flowcharts from PRD/docs/codebase with evidence maps. Use when creating user flow diagrams.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/**), Bash(cp:*), Task, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [source_type] [paths...] [goal] [scope?]
+argument-hint: "[source_type] [paths...] [goal] [scope?]"
 license: PROPRIETARY
 ---
 

--- a/skills/ux-heatmap-analyze/SKILL.md
+++ b/skills/ux-heatmap-analyze/SKILL.md
@@ -2,7 +2,7 @@
 name: ux-heatmap-analyze
 description: Analyze heatmap data from CSV exports and screenshots to generate prioritized UX reports. Use when interpreting heatmap data.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/**), Bash(cp:*), Edit(jaan-to/config/settings.yaml)
-argument-hint: [csv-path] [screenshot-path] [html-path?] [problem?]
+argument-hint: "[csv-path] [screenshot-path] [html-path?] [problem?]"
 license: PROPRIETARY
 ---
 

--- a/skills/ux-microcopy-write/SKILL.md
+++ b/skills/ux-microcopy-write/SKILL.md
@@ -2,7 +2,7 @@
 name: ux-microcopy-write
 description: Generate multi-language microcopy packs for UI components with cultural adaptation. Use when writing UI text and translations.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/**), Write($JAAN_CONTEXT_DIR/localization.md), Write($JAAN_CONTEXT_DIR/tone-of-voice.md), WebSearch, Task, AskUserQuestion, Bash(source:*), Bash(mkdir:*), Edit(jaan-to/config/settings.yaml)
-argument-hint: [initiative-or-feature-description]
+argument-hint: "[initiative-or-feature-description]"
 license: PROPRIETARY
 ---
 

--- a/skills/ux-research-synthesize/SKILL.md
+++ b/skills/ux-research-synthesize/SKILL.md
@@ -2,7 +2,7 @@
 name: ux-research-synthesize
 description: Synthesize UX research findings into themed insights and prioritized recommendations. Use when analyzing research data.
 allowed-tools: Read, Glob, Grep, Write($JAAN_OUTPUTS_DIR/ux/research/**), Task, AskUserQuestion, Edit(jaan-to/config/settings.yaml)
-argument-hint: [study-name] [data-sources?]
+argument-hint: "[study-name] [data-sources?]"
 license: PROPRIETARY
 ---
 


### PR DESCRIPTION
Closes #188.

## Summary

Purely mechanical single-character transform to 63 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (63)

- `skills/dev-verify/SKILL.md`
- `docs/roadmap/plans/dev-app-develop.md`
- `docs/research/25-ai-workflow-enterprise-plugin-packs.md`
- `adapters/codex/skillpack/skills/pm-skill-discover/SKILL.md`
- `docs/research/22-data-microsoft-clarity.md`
- `docs/extending/create-skill.md`
- `docs/research/34-ai-workflow-claude-code-skills-official.md`
- `docs/research/23-ai-workflow-claude-code-plugin-standards.md`
- `skills/dev-output-integrate/SKILL.md`
- `skills/ux-microcopy-write/SKILL.md`
- `docs/roadmap/plans/dev-scaffold-skills.md`
- `docs/roadmap/plans/ux-flowchart-generate.md`
- `adapters/codex/skillpack/runtime/docs/extending/create-skill.md`
- `skills/skill-update/SKILL.md`
- `adapters/codex/skillpack/skills/pm-prd-write/SKILL.md`
- `adapters/codex/skillpack/skills/pm-roadmap-add/SKILL.md`
- `skills/ux-flowchart-generate/SKILL.md`
- `skills/pm-story-write/SKILL.md`
- `skills/ux-heatmap-analyze/SKILL.md`
- `adapters/codex/skillpack/skills/dev-docs-fetch/SKILL.md`
- `adapters/codex/skillpack/skills/backend-service-implement/SKILL.md`
- `adapters/codex/skillpack/skills/dev-verify/SKILL.md`
- `adapters/codex/skillpack/skills/backend-task-breakdown/SKILL.md`
- `skills/pm-skill-discover/SKILL.md`
- `skills/dev-project-assemble/SKILL.md`
- `skills/dev-docs-fetch/SKILL.md`
- `skills/skill-create/SKILL.md`
- `skills/devops-deploy-activate/SKILL.md`
- `adapters/codex/skillpack/skills/ux-flowchart-generate/SKILL.md`
- `skills/data-gtm-datalayer/SKILL.md`
- `adapters/codex/skillpack/skills/skill-update/SKILL.md`
- `skills/backend-api-contract/SKILL.md`
- `adapters/codex/skillpack/skills/pm-story-write/SKILL.md`
- `skills/backend-service-implement/SKILL.md`
- `skills/pm-prd-write/SKILL.md`
- `skills/backend-scaffold/SKILL.md`
- `skills/frontend-scaffold/SKILL.md`
- `skills/pm-roadmap-add/SKILL.md`
- `adapters/codex/skillpack/skills/backend-scaffold/SKILL.md`
- `adapters/codex/skillpack/skills/ux-microcopy-write/SKILL.md`
- `skills/backend-data-model/SKILL.md`
- `adapters/codex/skillpack/skills/ux-research-synthesize/SKILL.md`
- `adapters/codex/skillpack/skills/skill-create/SKILL.md`
- `skills/frontend-design/SKILL.md`
- `adapters/codex/skillpack/skills/devops-deploy-activate/SKILL.md`
- `skills/frontend-task-breakdown/SKILL.md`
- `adapters/codex/skillpack/skills/dev-output-integrate/SKILL.md`
- `skills/ux-research-synthesize/SKILL.md`
- `adapters/codex/skillpack/skills/backend-data-model/SKILL.md`
- `adapters/codex/skillpack/skills/data-gtm-datalayer/SKILL.md`
- `adapters/codex/skillpack/skills/backend-api-contract/SKILL.md`
- `adapters/codex/skillpack/skills/frontend-task-breakdown/SKILL.md`
- `adapters/codex/skillpack/skills/ux-heatmap-analyze/SKILL.md`
- `skills/backend-task-breakdown/SKILL.md`
- `adapters/codex/skillpack/skills/frontend-design/SKILL.md`
- `adapters/codex/skillpack/skills/dev-project-assemble/SKILL.md`
- `adapters/codex/skillpack/skills/frontend-scaffold/SKILL.md`
- `skills/qa-test-run/SKILL.md`
- `skills/qa-test-cases/SKILL.md`
- `skills/qa-test-generate/SKILL.md`
- `adapters/codex/skillpack/skills/qa-test-run/SKILL.md`
- `adapters/codex/skillpack/skills/qa-test-cases/SKILL.md`
- `adapters/codex/skillpack/skills/qa-test-generate/SKILL.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized argument hints across skill definitions and documentation examples.
  * Hints are now consistently represented as quoted strings, preserving placeholders, options, and interactive usage formats.
  * Updated backend, frontend, development, product, QA, and UX skill references for consistent input guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->